### PR TITLE
[BUGFIX] GeneralyUtility::getFileAbsFileName could not be used for absolute path in TYPO3 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - env: TYPO3_VERSION="dev-master"
-    - php: 7.0
 
 before_install:
   - composer self-update

--- a/Classes/Report/TikaStatus.php
+++ b/Classes/Report/TikaStatus.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Tika\Report;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Tika\Utility\FileUtility;
 use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Reports\Status;
@@ -250,7 +251,7 @@ class TikaStatus implements StatusProviderInterface
      */
     protected function isFilePresent($fileName)
     {
-        return is_file(GeneralUtility::getFileAbsFileName($fileName, false));
+        return is_file(FileUtility::getAbsoluteFilePath($fileName));
     }
 
     /**

--- a/Classes/Service/Tika/AppService.php
+++ b/Classes/Service/Tika/AppService.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Tika\Service\Tika;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Tika\Utility\FileUtility;
 use ApacheSolrForTypo3\Tika\Utility\ShellUtility;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Utility\CommandUtility;
@@ -44,8 +45,7 @@ class AppService extends AbstractService
      */
     protected function initializeService()
     {
-        if (!is_file(GeneralUtility::getFileAbsFileName($this->configuration['tikaPath'],
-            false))
+        if (!is_file(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']))
         ) {
             throw new \RuntimeException(
                 'Invalid path or filename for Tika application jar: ' . $this->configuration['tikaPath'],
@@ -67,8 +67,7 @@ class AppService extends AbstractService
     {
         $tikaCommand = CommandUtility::getCommand('java')
             . ' -Dfile.encoding=UTF8' // forces UTF8 output
-            . ' -jar ' . escapeshellarg(GeneralUtility::getFileAbsFileName($this->configuration['tikaPath'],
-                false))
+            . ' -jar ' . escapeshellarg(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']))
             . ' -V';
 
         return shell_exec($tikaCommand);
@@ -86,8 +85,7 @@ class AppService extends AbstractService
         $tikaCommand = ShellUtility::getLanguagePrefix()
             . CommandUtility::getCommand('java')
             . ' -Dfile.encoding=UTF8' // forces UTF8 output
-            . ' -jar ' . escapeshellarg(GeneralUtility::getFileAbsFileName($this->configuration['tikaPath'],
-                false))
+            . ' -jar ' . escapeshellarg(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']))
             . ' -t'
             . ' ' . ShellUtility::escapeShellArgument($localTempFilePath);
 
@@ -115,8 +113,7 @@ class AppService extends AbstractService
         $tikaCommand = ShellUtility::getLanguagePrefix()
             . CommandUtility::getCommand('java')
             . ' -Dfile.encoding=UTF8'
-            . ' -jar ' . escapeshellarg(GeneralUtility::getFileAbsFileName($this->configuration['tikaPath'],
-                false))
+            . ' -jar ' . escapeshellarg(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']))
             . ' -m'
             . ' ' . ShellUtility::escapeShellArgument($localTempFilePath);
 
@@ -182,8 +179,7 @@ class AppService extends AbstractService
         $tikaCommand = ShellUtility::getLanguagePrefix()
             . CommandUtility::getCommand('java')
             . ' -Dfile.encoding=UTF8'
-            . ' -jar ' . escapeshellarg(GeneralUtility::getFileAbsFileName($this->configuration['tikaPath'],
-                false))
+            . ' -jar ' . escapeshellarg(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']))
             . ' -l'
             . ' ' . ShellUtility::escapeShellArgument($localFilePath);
 
@@ -260,7 +256,7 @@ class AppService extends AbstractService
      */
     public function isAvailable()
     {
-        $tikaFileExists = is_file(GeneralUtility::getFileAbsFileName($this->configuration['tikaPath'], false));
+        $tikaFileExists = is_file(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']));
         if (!$tikaFileExists) {
             return false;
         }

--- a/Classes/Service/Tika/ServerService.php
+++ b/Classes/Service/Tika/ServerService.php
@@ -24,6 +24,7 @@ namespace ApacheSolrForTypo3\Tika\Service\Tika;
  *  This copyright notice MUST APPEAR in all copies of the script!
  ***************************************************************/
 
+use ApacheSolrForTypo3\Tika\Utility\FileUtility;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -79,10 +80,7 @@ class ServerService extends AbstractService
      */
     protected function getStartCommand()
     {
-        $tikaJar = GeneralUtility::getFileAbsFileName(
-            $this->configuration['tikaServerPath'],
-            false
-        );
+        $tikaJar = FileUtility::getAbsoluteFilePath($this->configuration['tikaServerPath']);
         $command = '-jar ' . escapeshellarg($tikaJar);
         $command .= ' -p ' . escapeshellarg($this->configuration['tikaServerPort']);
 

--- a/Classes/Utility/FileUtility.php
+++ b/Classes/Utility/FileUtility.php
@@ -1,0 +1,40 @@
+<?php
+namespace ApacheSolrForTypo3\Tika\Utility;
+
+/**
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Class ShellUtility
+ */
+class FileUtility
+{
+    /**
+     * @param string $path
+     * @return string
+     */
+    public static function getAbsoluteFilePath($path) {
+        if (version_compare(TYPO3_version, '8.0', '<')) {
+            return GeneralUtility::getFileAbsFileName($path, false);
+        } else {
+            if (substr($path, 0, 1) === "/") {
+                // if the path start with a "/" we thread it as absolute
+                return $path;
+            } else {
+                return GeneralUtility::getFileAbsFileName($path);
+            }
+        }
+    }
+}


### PR DESCRIPTION
GeneralyUtility::getFileAbsFileName could not be used for absolute path in TYPO3 8.0

Fixes: #23