### PR TITLE
[BUGFIX] only use the first 3 signs in version compare

### DIFF
--- a/Classes/Service/Tika/SolrCellService.php
+++ b/Classes/Service/Tika/SolrCellService.php
@@ -94,7 +94,7 @@ class SolrCellService extends AbstractService
         $query->setExtractOnly();
 
         // todo: this can be removed when we drop EXT:solr 3.1 compatibility
-        $solrVersion = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('solr');
+        $solrVersion = $this->getExtSolrVersion();
         if(version_compare($solrVersion, '3.1', '>')) {
             $response = $this->solr->extractByQuery($query);
         } else {
@@ -129,7 +129,7 @@ class SolrCellService extends AbstractService
         $query->setExtractOnly();
 
         // todo: this can be removed when we drop EXT:solr 3.1 compatibility
-        $solrVersion = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('solr');
+        $solrVersion = $this->getExtSolrVersion();
         if(version_compare($solrVersion, '3.1', '>')) {
             $response = $this->solr->extractByQuery($query);
         } else {
@@ -148,6 +148,19 @@ class SolrCellService extends AbstractService
         ));
 
         return $metaData;
+    }
+
+    /**
+    * Gets the Solr Version reduced to major and minor digits
+    *
+    * @return float
+    */
+    protected function getExtSolrVersion()
+    {
+        $solrVersion = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::getExtensionVersion('solr');
+        $strippedSolrVersion = substr($solrVersion, 0, 3);
+
+        return $strippedSolrVersion;
     }
 
     /**


### PR DESCRIPTION
* Only use the first 3 signs in version compare
Fixes: #26