### PR TITLE
[BUG] Unsupported exception leads to error in uploads

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,7 +5,11 @@ if (!defined('TYPO3_MODE')) {
 
 $metaDataExtractorRegistry = \TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::getInstance();
 $metaDataExtractorRegistry->registerExtractionService('ApacheSolrForTypo3\\Tika\\Service\\Extractor\\MetaDataExtractor');
-$metaDataExtractorRegistry->registerExtractionService('ApacheSolrForTypo3\\Tika\\Service\\Extractor\\LanguageDetector');
+$extConf = unserialize($_EXTCONF);
+if ($extConf['extractor'] !== 'solr') {
+    $metaDataExtractorRegistry->registerExtractionService('ApacheSolrForTypo3\\Tika\\Service\\Extractor\\LanguageDetector');
+}
+unset($extConf);
 
 if (version_compare(TYPO3_version, '7.1', '>')) {
     $textExtractorRegistry = \TYPO3\CMS\Core\Resource\TextExtraction\TextExtractorRegistry::getInstance();


### PR DESCRIPTION
Unsupported exception in ```SolrCellService::detectLanguageFromFile```
prevents file upload to be reported successfully.

Tika language extractor is now not registered when SOLR is used as extractor.
Thus not triggerring the exception.