### PR TITLE
[TASK] Make EXT:tika compatible to Apache Tika 1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
 
 env:
   global:
-    - TIKA_VERSION="1.13"
+    - TIKA_VERSION="1.14"
     - TIKA_PATH=$HOME/tika
   matrix:
     - TYPO3_VERSION="~7.6.5"

--- a/Build/Test/bootstrap.sh
+++ b/Build/Test/bootstrap.sh
@@ -10,7 +10,7 @@ if [[ $* == *--local* ]]; then
     read typo3Version
     export TYPO3_VERSION=$typo3Version
 
-    echo -n "Choose a tika Version (e.g. 1.13): "
+    echo -n "Choose a tika Version (e.g. 1.14): "
     read tikaVersion
     export TIKA_VERSION=$tikaVersion
 

--- a/Classes/Service/Tika/ServerService.php
+++ b/Classes/Service/Tika/ServerService.php
@@ -179,7 +179,7 @@ class ServerService extends AbstractService
         $tikaPing = $this->queryTika('/tika');
         $tikaReachable = GeneralUtility::isFirstPartOfStr(
             $tikaPing,
-            'This is Tika Server.'
+            'This is Tika Server'
         );
 
         return $tikaReachable;

--- a/Resources/Docker/Dockerfile
+++ b/Resources/Docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:trusty
 MAINTAINER ingo@typo3.org
 
-ENV TIKA_VERSION 1.10
+ENV TIKA_VERSION 1.14
 
 # install dependencies
 # Java 8 is not available for trusty/14.04

--- a/Tests/Integration/Service/Tika/ServerServiceTest.php
+++ b/Tests/Integration/Service/Tika/ServerServiceTest.php
@@ -370,4 +370,17 @@ class ServerServiceTest extends UnitTestCase
         $this->assertContains('application/pdf', $mimeTypes, 'Server did not indicate to support pdf documents');
         $this->assertContains('application/vnd.openxmlformats-officedocument.wordprocessingml.document', $mimeTypes, 'Server did not indicate to support docx documents');
     }
+
+
+    /**
+     * @test
+     */
+    public function canPing()
+    {
+        $service = new ServerService($this->getTikaServerConfiguration());
+        $pingResult = $service->ping();
+
+        $this->assertTrue($pingResult, 'Could not ping tika server');
+    }
+
 }


### PR DESCRIPTION
This pr:

* Fixes the ping patter from "This is Tika Server." to "This is Tika Server"
because the output was changed to "This is Tika Server (Apache Tika 1.14). Please PUT\n".
With this changes it's compatible to 1.13
* Adds an integration test for ping to notice changes
* Use Tika 1.14 in build and for docker container

Fixes: #43