### PR TITLE
adding logging for Tika Server, log warnings in devLog when request f…

### DIFF
--- a/Classes/Service/Tika/AbstractService.php
+++ b/Classes/Service/Tika/AbstractService.php
@@ -87,16 +87,17 @@ abstract class AbstractService implements ServiceInterface
      *
      * @param string $message Log message
      * @param array $data Optional data
+	 * @param integer $severity Severity: 0 is info, 1 is notice, 2 is warning, 3 is fatal error, -1 is "OK" message
      * @return void
      */
-    protected function log($message, array $data = [])
+    protected function log($message, array $data = [], $severity = 0)
     {
         // TODO refactor to have logger injected
         if (!$this->configuration['logging']) {
             return;
         }
 
-        GeneralUtility::devLog($message, 'tika', 0, $data);
+        GeneralUtility::devLog($message, 'tika', $severity, $data);
     }
 
     /**

--- a/Classes/Service/Tika/ServerService.php
+++ b/Classes/Service/Tika/ServerService.php
@@ -278,6 +278,12 @@ class ServerService extends AbstractService
 
         $response = $this->queryTika('/tika', $context);
 
+		if($response === FALSE) {
+			$this->log('Text Extraction using Tika Server failed', $this->getLogData($file, $response), 2);
+		} else {
+			$this->log('Text Extraction using Tika Server', $this->getLogData($file, $response));
+		}
+
         return $response;
     }
 
@@ -308,7 +314,14 @@ class ServerService extends AbstractService
         $rawResponse = $this->queryTika('/meta', $context);
         $response = (array)json_decode($rawResponse);
 
-        return $response;
+		if($response === FALSE) {
+			$this->log('Meta Data Extraction using Tika Server failed', $this->getLogData($file, $response), 2);
+		} else {
+			$this->log('Meta Data Extraction using Tika Server', $this->getLogData($file, $response));
+		}
+
+
+		return $response;
     }
 
     /**
@@ -336,7 +349,13 @@ class ServerService extends AbstractService
 
         $response = $this->queryTika('/language/stream', $context);
 
-        return $response;
+		if($response === FALSE) {
+			$this->log('Language Detection using Tika Server failed', $this->getLogData($file, $response), 2);
+		}else{
+			$this->log('Language Detection using Tika Server', $this->getLogData($file, $response));
+		}
+
+		return $response;
     }
 
     /**
@@ -429,4 +448,20 @@ class ServerService extends AbstractService
         asort($supportedTypes);
         return $supportedTypes;
     }
+
+	/**
+	 * @param \TYPO3\CMS\Core\Resource\FileInterface $file
+	 * @param string $response
+	 * @return array
+	 */
+	protected function getLogData($file, $response){
+
+		$logData = array(
+			'file' => $file->getName(),
+			'file_path' => $file->getPublicUrl(),
+			'tika_url' => $this->getTikaServerUrl(),
+			'response' => $response
+		);
+		return $logData;
+	}
 }


### PR DESCRIPTION
…ails

also: added the possibility to define the severity in the local log-function

the Problem I solved: When you send Tika an encrypted PDF to parse, file_get_contents doesn't throw an Exception, but a PHP Warning and you can't find the file that causes the warning. Now this situation results in a devLog Entry, so at least you know what files don't work.

Example log entry ![screenshot from 2017-02-01 14-00-32](https://cloud.githubusercontent.com/assets/18674199/22507686/09a1ec60-e887-11e6-85bf-3328c5f7620a.png)
