### PR TITLE
[BUGFIX] Unlink tempfile only when it exists

### DIFF
--- a/Classes/Service/Tika/AbstractService.php
+++ b/Classes/Service/Tika/AbstractService.php
@@ -77,7 +77,7 @@ abstract class AbstractService implements ServiceInterface
         $localTempFilePath,
         FileInterface $sourceFile
     ) {
-        if (PathUtility::basename($localTempFilePath) !== $sourceFile->getName()) {
+        if (PathUtility::basename($localTempFilePath) !== $sourceFile->getName() && file_exists($localTempFilePath)) {
             unlink($localTempFilePath);
         }
     }


### PR DESCRIPTION
When the tempfile was allready cleanedup it is not required to unlink it.
In this case the unlinking can be skipped.

Fixes: #78