### PR TITLE
[BUGFIX] Do not unlink temporary files

### DIFF
--- a/Classes/Service/Tika/AbstractService.php
+++ b/Classes/Service/Tika/AbstractService.php
@@ -64,25 +64,6 @@ abstract class AbstractService implements ServiceInterface
     }
 
     /**
-     * Removes a temporary file.
-     *
-     * When working with a file, the actual file might be on a remote storage.
-     * To work with it it gets copied to local storage, those temporary local
-     * copies need to be removed when they're not needed anymore.
-     *
-     * @param string $localTempFilePath Path to the local file copy
-     * @param \TYPO3\CMS\Core\Resource\FileInterface $sourceFile Original file
-     */
-    protected function cleanupTempFile(
-        $localTempFilePath,
-        FileInterface $sourceFile
-    ) {
-        if (PathUtility::basename($localTempFilePath) !== $sourceFile->getName() && file_exists($localTempFilePath)) {
-            unlink($localTempFilePath);
-        }
-    }
-
-    /**
      * Logs a message and optionally data to devlog
      *
      * @param string $message Log message

--- a/Classes/Service/Tika/AppService.php
+++ b/Classes/Service/Tika/AppService.php
@@ -94,7 +94,6 @@ class AppService extends AbstractService
             . ' ' . ShellUtility::escapeShellArgument($localTempFilePath);
 
         $extractedText = shell_exec($tikaCommand);
-        $this->cleanupTempFile($localTempFilePath, $file);
 
         $this->log('Text Extraction using local Tika', [
             'file' => $file,
@@ -124,7 +123,6 @@ class AppService extends AbstractService
         $shellOutput = [];
         exec($tikaCommand, $shellOutput);
         $metaData = $this->shellOutputToArray($shellOutput);
-        $this->cleanupTempFile($localTempFilePath, $file);
 
         $this->log('Meta Data Extraction using local Tika', [
             'file' => $file,
@@ -145,11 +143,8 @@ class AppService extends AbstractService
     public function detectLanguageFromFile(FileInterface $file)
     {
         $localTempFilePath = $file->getForLocalProcessing(false);
-        $language = $this->detectLanguageFromLocalFile($localTempFilePath);
 
-        $this->cleanupTempFile($localTempFilePath, $file);
-
-        return $language;
+        return $this->detectLanguageFromLocalFile($localTempFilePath);
     }
 
     /**

--- a/Classes/Service/Tika/SolrCellService.php
+++ b/Classes/Service/Tika/SolrCellService.php
@@ -97,8 +97,6 @@ class SolrCellService extends AbstractService
         $writer = $this->solrConnection->getWriteService();
         $response = $writer->extractByQuery($query);
 
-        $this->cleanupTempFile($localTempFilePath, $file);
-
         $this->log('Text Extraction using Solr', [
             'file' => $file,
             'solr connection' => (array)$writer,
@@ -128,7 +126,6 @@ class SolrCellService extends AbstractService
         $response = $writer->extractByQuery($query);
 
         $metaData = $this->solrResponseToArray($response[1]);
-        $this->cleanupTempFile($localTempFilePath, $file);
 
         $this->log('Meta Data Extraction using Solr', [
             'file' => $file,

--- a/Tests/Unit/Service/Tika/SolrCellServiceTest.php
+++ b/Tests/Unit/Service/Tika/SolrCellServiceTest.php
@@ -126,28 +126,6 @@ class SolrCellServiceTest extends ServiceUnitTestCase
         $service->extractText($file);
     }
 
-    /**
-     * @test
-     */
-    public function extractTextCleansUpTempFile()
-    {
-        $serviceMock = $this->getMockBuilder(SolrCellService::class)
-            ->setConstructorArgs([$this->getConfiguration()])
-            ->setMethods(['cleanupTempFile'])
-            ->getMock();
-        $serviceMock->expects($this->once())->method('cleanupTempFile');
-
-        $file = new File(
-            [
-                'identifier' => 'testWORD.doc',
-                'name' => 'testWORD.doc'
-            ],
-            $this->documentsStorageMock
-        );
-
-        $serviceMock->extractText($file);
-    }
-
     #TODO test return value, conversion of response to array
 
     /**
@@ -180,43 +158,4 @@ class SolrCellServiceTest extends ServiceUnitTestCase
 
         $service->extractMetaData($file);
     }
-
-    /**
-     * @test
-     */
-    public function extractMetaDataCleansUpTempFile()
-    {
-        $solrWriter = $this->prophesize(SolrWriteService::class);
-        $solrWriter->extractByQuery(Argument::type(Query::class))
-            ->shouldBeCalled()
-            ->willReturn([
-                    'foo', // extracted text is index 0
-                    ['bar'] // meta data is index 1
-                ]
-            );
-
-        $connectionMock = $this->prophesize(SolrConnection::class);
-        $connectionMock->getWriteService()->shouldBeCalled()->willReturn($solrWriter);
-
-
-        $serviceMock = $this->getMockBuilder(SolrCellService::class)
-            ->setConstructorArgs([$this->getConfiguration()])
-            ->setMethods(['cleanupTempFile'])
-            ->getMock();
-
-        $this->inject($serviceMock, 'solrConnection', $connectionMock->reveal());
-
-        $serviceMock->expects($this->once())->method('cleanupTempFile');
-
-        $file = new File(
-            [
-                'identifier' => 'testWORD.doc',
-                'name' => 'testWORD.doc'
-            ],
-            $this->documentsStorageMock
-        );
-
-        $serviceMock->extractMetaData($file);
-    }
-
 }


### PR DESCRIPTION
When fetching files for local processing the FAL API defines
two ways to do so.

1. Fetch the file for modification
2. Fetch the file only for reading

In the first case the consumer of the API is responsible
for cleaning the temporary file after usage.

In the second case the driver is responsible
for cleaning up the temporary file at any point in time
when the driver considers it appropriate.

Since the tika extension always fetches the file only for reading,
and the API clearly states, that for such case NO modifications
must be done to the file (and removing it is clearly a pretty severe modification),
the local file must not be removed at all.

This is important for remote storage drivers that do some optimizations
to keep the local file cached during one request, to speed up operations on those
on subsequent calls for processing.