### PR TITLE
Tika extracts and saves wrong width/height metadata of jpegs (EXIF)

### DIFF
--- a/Classes/Service/Extractor/MetaDataExtractor.php
+++ b/Classes/Service/Extractor/MetaDataExtractor.php
@@ -153,14 +153,14 @@ class MetaDataExtractor extends AbstractExtractor
                 case 'height':
                     $metaDataCleaned['height'] = $value;
                     break;
-                case 'Image Height':
+                case 'Exif Image Height':
                     list($height) = explode(' ', $value, 2);
                     $metaDataCleaned['height'] = $height;
                     break;
                 case 'width':
                     $metaDataCleaned['width'] = $value;
                     break;
-                case 'Image Width':
+                case 'Exif Image Width':
                     list($width) = explode(' ', $value, 2);
                     $metaDataCleaned['width'] = $width;
                     break;

--- a/Tests/Unit/Service/Extractor/MetaDataExtractorTest.php
+++ b/Tests/Unit/Service/Extractor/MetaDataExtractorTest.php
@@ -57,6 +57,8 @@ class MetaDataExtractorTest extends UnitTestCase
             'File Size' => "7686 bytes",
             'Image Height' => "75 pixels",
             'Image Width' => "100 pixels",
+            'Exif Image Height' => "75 pixels",
+            'Exif Image Width' => "100 pixels",
             'JPEG Comment' => "Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE file distributed with this work for additional information regarding copyright ownership.",
             'Number of Components' => "3",
             'Resolution Units' => "inch",


### PR DESCRIPTION
Issue described here: https://github.com/TYPO3-Solr/ext-tika/issues/84