### PR TITLE
prevent getting exception while metadata extract

### DIFF
--- a/Classes/Service/Tika/SolrCellService.php
+++ b/Classes/Service/Tika/SolrCellService.php
@@ -124,8 +124,11 @@ class SolrCellService extends AbstractService
 
         $writer = $this->solrConnection->getWriteService();
         $response = $writer->extractByQuery($query);
-
-        $metaData = $this->solrResponseToArray($response[1]);
+        
+        $metaData = [];
+        if (isset($response[1]) && is_array($response[1])) {
+            $metaData = $this->solrResponseToArray($response[1]);
+        }
 
         $this->log('Meta Data Extraction using Solr', [
             'file' => $file,


### PR DESCRIPTION
If the solr writer cannot extract any informations for a file (and delivers an empty array), we have to check for this, before we manage the response. The function `solrResponseToArray` can only handle an array, but not null. Therefore we need this check before.