### PR TITLE
[FEATURE] Allow driver configuration for extractor services

### DIFF
--- a/Classes/Service/Extractor/AbstractExtractor.php
+++ b/Classes/Service/Extractor/AbstractExtractor.php
@@ -88,9 +88,7 @@ abstract class AbstractExtractor implements ExtractorInterface
      */
     public function getDriverRestrictions()
     {
-        return [
-            'Local',
-        ];
+        return $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tika']['extractor']['driverRestrictions'];
     }
 
     /**

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,6 +2,16 @@
 // Prevent Script from beeing called directly
 defined('TYPO3_MODE') || die();
 
+if (empty($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tika']['extractor']['driverRestrictions'])) {
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tika']['extractor']['driverRestrictions'] = [];
+}
+$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tika']['extractor']['driverRestrictions'] = array_merge(
+    [
+        'Local',
+    ],
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tika']['extractor']['driverRestrictions']
+);
+
 $metaDataExtractorRegistry = \TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::getInstance();
 $metaDataExtractorRegistry->registerExtractionService(\ApacheSolrForTypo3\Tika\Service\Extractor\MetaDataExtractor::class);
 


### PR DESCRIPTION
To be able to extract data for files from file storages with other drivers, a
configuration option is added to the extension.

Usage:

```
$GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tika']['extractor']['driverRestrictions'][] = 'MaxServ.FalS3';
```

Fixes: #122, #123