### PR TITLE
[TASK] Refactor logging

### DIFF
--- a/Classes/Report/TikaStatus.php
+++ b/Classes/Report/TikaStatus.php
@@ -1,28 +1,18 @@
 <?php
 namespace ApacheSolrForTypo3\Tika\Report;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2010-2015 Ingo Renner <ingo@typo3.org>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Solr\ConnectionManager;
 use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
@@ -30,6 +20,7 @@ use ApacheSolrForTypo3\Tika\Service\Tika\ServerService;
 use ApacheSolrForTypo3\Tika\Util;
 use ApacheSolrForTypo3\Tika\Utility\FileUtility;
 use Exception;
+use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Solarium\QueryType\Extract\Query;
 use TYPO3\CMS\Core\Utility\CommandUtility;
@@ -42,8 +33,9 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
  * Provides a status report about whether Tika is properly configured
  *
  * @author Ingo Renner <ingo@typo3.org>
+ * @copyright (c) 2010-2015 Ingo Renner <ingo@typo3.org>
  */
-class TikaStatus implements StatusProviderInterface
+class TikaStatus implements StatusProviderInterface, LoggerAwareInterface
 {
     use LoggerAwareTrait;
 
@@ -285,7 +277,7 @@ class TikaStatus implements StatusProviderInterface
      * @param string $extKey extension key
      * @param array $data data
      */
-    protected function writeDevLog($message, $extKey, $data = [])
+    protected function writeDevLog(string $message, string $extKey, array $data = [])
     {
         $this->logger->debug(
             $message,

--- a/Classes/Service/Extractor/AbstractExtractor.php
+++ b/Classes/Service/Extractor/AbstractExtractor.php
@@ -1,33 +1,24 @@
 <?php
 namespace ApacheSolrForTypo3\Tika\Service\Extractor;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2015 Ingo Renner <ingo@typo3.org>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Tika\Service\File\SizeValidator;
 use ApacheSolrForTypo3\Tika\Util;
-use TYPO3\CMS\Core\Log\Logger;
-use TYPO3\CMS\Core\Log\LogManager;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LogLevel;
 use TYPO3\CMS\Core\Resource\Index\ExtractorInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
@@ -36,9 +27,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * Class AbstractExtractor
  *
  * @package ApacheSolrForTypo3\Tika\Service\Extractor
+ * @copyright (c) 2015 Ingo Renner <ingo@typo3.org>
  */
-abstract class AbstractExtractor implements ExtractorInterface
+abstract class AbstractExtractor implements ExtractorInterface, LoggerAwareInterface
 {
+    use LoggerAwareTrait;
 
     /**
      * @var array
@@ -112,21 +105,22 @@ abstract class AbstractExtractor implements ExtractorInterface
     }
 
     /**
-     * Logs a message and optionally data to devlog
+     * Logs a message and optionally data to log file
      *
      * @param string $message Log message
      * @param array $data Optional data
      * @return void
      */
-    protected function log($message, array $data = [])
+    protected function log(string $message, array $data = [])
     {
         if (!$this->configuration['logging']) {
             return;
         }
-
-        /* @var Logger $logger */
-        $logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
-        $logger->log(0, $message, $data);
+        $this->logger->log(
+            LogLevel::DEBUG, // Previous value 0
+            $message,
+            $data
+        );
     }
 
 }

--- a/Classes/Service/Tika/AbstractService.php
+++ b/Classes/Service/Tika/AbstractService.php
@@ -1,46 +1,37 @@
 <?php
 namespace ApacheSolrForTypo3\Tika\Service\Tika;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2015 Ingo Renner <ingo@typo3.org>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
-use TYPO3\CMS\Core\Log\Logger;
-use TYPO3\CMS\Core\Log\LogManager;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LogLevel;
 
 /**
  * Abstract Tika service implementing shared methods
  *
  * @package ApacheSolrForTypo3\Tika\Service
+ * @copyright (c) 2015 Ingo Renner <ingo@typo3.org>
  */
-abstract class AbstractService implements ServiceInterface
+abstract class AbstractService implements ServiceInterface, LoggerAwareInterface
 {
+    use LoggerAwareTrait;
 
     /**
      * @var array
      */
     protected $configuration;
-
 
     /**
      * Constructor
@@ -63,23 +54,24 @@ abstract class AbstractService implements ServiceInterface
     }
 
     /**
-     * Logs a message and optionally data to devlog
+     * Logs a message and optionally data to log file
      *
      * @param string $message Log message
      * @param array $data Optional data
-     * @param integer $severity Severity: 0 is info, 1 is notice, 2 is warning, 3 is fatal error, -1 is "OK" message
+     * @param integer|string $severity Use constants from class LogLevel
      * @return void
+     * @see LogLevel For supported log levels
      */
-    protected function log($message, array $data = [], $severity = 0)
+    protected function log(string $message, array $data = [], $severity = LogLevel::DEBUG)
     {
-        // TODO refactor to have logger injected
         if (!$this->configuration['logging']) {
             return;
         }
-
-        /* @var Logger $logger */
-        $logger = GeneralUtility::makeInstance(LogManager::class)->getLogger(__CLASS__);
-        $logger->log($severity, $message, $data);
+        $this->logger->log(
+            $severity,
+            $message,
+            $data
+        );
     }
 
     /**

--- a/Classes/Service/Tika/AppService.php
+++ b/Classes/Service/Tika/AppService.php
@@ -1,28 +1,18 @@
 <?php
 namespace ApacheSolrForTypo3\Tika\Service\Tika;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2015 Ingo Renner <ingo@typo3.org>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Tika\Utility\FileUtility;
 use ApacheSolrForTypo3\Tika\Utility\ShellUtility;
@@ -31,10 +21,10 @@ use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-
 /**
  * A Tika service implementation using the tika-app.jar
  *
+ * @copyright (c) 2015 Ingo Renner <ingo@typo3.org>
  */
 class AppService extends AbstractService
 {
@@ -96,11 +86,14 @@ class AppService extends AbstractService
 
         $extractedText = shell_exec($tikaCommand);
 
-        $this->log('Text Extraction using local Tika', [
-            'file' => $file,
-            'tika command' => $tikaCommand,
-            'shell output' => $extractedText
-        ]);
+        $this->log(
+            'Text Extraction using local Tika',
+            [
+                'file' => $file,
+                'tika command' => $tikaCommand,
+                'shell output' => $extractedText
+            ]
+        );
 
         return $extractedText;
     }
@@ -125,12 +118,15 @@ class AppService extends AbstractService
         exec($tikaCommand, $shellOutput);
         $metaData = $this->shellOutputToArray($shellOutput);
 
-        $this->log('Meta Data Extraction using local Tika', [
-            'file' => $file,
-            'tika command' => $tikaCommand,
-            'shell output' => $shellOutput,
-            'meta data' => $metaData
-        ]);
+        $this->log(
+            'Meta Data Extraction using local Tika',
+            [
+                'file' => $file,
+                'tika command' => $tikaCommand,
+                'shell output' => $shellOutput,
+                'meta data' => $metaData
+            ]
+        );
 
         return $metaData;
     }
@@ -185,11 +181,14 @@ class AppService extends AbstractService
 
         $language = trim(shell_exec($tikaCommand));
 
-        $this->log('Language Detection using local Tika', [
-            'file' => $localFilePath,
-            'tika command' => $tikaCommand,
-            'shell output' => $language
-        ]);
+        $this->log(
+            'Language Detection using local Tika',
+            [
+                'file' => $localFilePath,
+                'tika command' => $tikaCommand,
+                'shell output' => $language
+            ]
+        );
 
         return $language;
     }

--- a/Classes/Service/Tika/ServerService.php
+++ b/Classes/Service/Tika/ServerService.php
@@ -308,10 +308,13 @@ class ServerService extends AbstractService
             $this->log(
                 'Text Extraction using Tika Server failed',
                 $this->getLogData($file, $response),
-                LogLevel::CRITICAL
+                LogLevel::ERROR
             );
         } else {
-            $this->log('Text Extraction using Tika Server', $this->getLogData($file, $response));
+            $this->log(
+                'Text Extraction using Tika Server',
+                $this->getLogData($file, $response)
+            );
         }
 
         return $response;
@@ -340,12 +343,15 @@ class ServerService extends AbstractService
             $this->log(
                 'Meta Data Extraction using Tika Server failed',
                 $this->getLogData($file, $rawResponse),
-                LogLevel::CRITICAL
+                LogLevel::ERROR
             );
             return [];
         }
 
-        $this->log('Meta Data Extraction using Tika Server', $this->getLogData($file, $rawResponse));
+        $this->log(
+            'Meta Data Extraction using Tika Server',
+            $this->getLogData($file, $rawResponse)
+        );
         return $response;
     }
 
@@ -370,10 +376,13 @@ class ServerService extends AbstractService
             $this->log(
                 'Language Detection using Tika Server failed',
                 $this->getLogData($file, $response),
-                LogLevel::CRITICAL
+                LogLevel::ERROR
             );
         } else {
-            $this->log('Language Detection using Tika Server', $this->getLogData($file, $response));
+            $this->log(
+                'Language Detection using Tika Server',
+                $this->getLogData($file, $response)
+            );
         }
 
         return $response;

--- a/Tests/Integration/Service/Tika/AppServiceTest.php
+++ b/Tests/Integration/Service/Tika/AppServiceTest.php
@@ -1,37 +1,29 @@
 <?php
 namespace ApacheSolrForTypo3\Tika\Tests\Integration\Service\Tika;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2015 Ingo Renner <ingo@typo3.org>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Tika\Service\Tika\AppService;
 use ApacheSolrForTypo3\Tika\Tests\Unit\ExecRecorder;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Resource\File;
 
 
 /**
  * Test case for class AppService
  *
+ * @copyright (c) 2015 Ingo Renner <ingo@typo3.org>
  */
 class AppServiceTest extends ServiceIntegrationTestCase
 {
@@ -48,6 +40,7 @@ class AppServiceTest extends ServiceIntegrationTestCase
     public function getTikaVersionUsesVParameter()
     {
         $service = new AppService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->getTikaVersion();
 
         $this->assertContains('-V', ExecRecorder::$execCommand);
@@ -67,6 +60,7 @@ class AppServiceTest extends ServiceIntegrationTestCase
         );
 
         $service = new AppService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->extractText($file);
 
         $this->assertContains('-t', ExecRecorder::$execCommand);
@@ -87,6 +81,7 @@ class AppServiceTest extends ServiceIntegrationTestCase
         );
 
         $service = new AppService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->extractMetaData($file);
 
         $this->assertContains('-m', ExecRecorder::$execCommand);
@@ -106,6 +101,7 @@ class AppServiceTest extends ServiceIntegrationTestCase
         );
 
         $service = new AppService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->detectLanguageFromFile($file);
 
         $this->assertContains('-l', ExecRecorder::$execCommand);
@@ -117,6 +113,7 @@ class AppServiceTest extends ServiceIntegrationTestCase
     public function detectLanguageFromStringUsesLParameter()
     {
         $service = new AppService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->detectLanguageFromString('foo');
 
         $this->assertContains('-l', ExecRecorder::$execCommand);
@@ -128,6 +125,7 @@ class AppServiceTest extends ServiceIntegrationTestCase
     public function callsTikaAppCorrectlyToGetMimeList()
     {
         $service = new AppService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->getSupportedMimeTypes();
         $this->assertContains('--list-supported-types', ExecRecorder::$execCommand);
     }

--- a/Tests/Integration/Service/Tika/ServerServiceTest.php
+++ b/Tests/Integration/Service/Tika/ServerServiceTest.php
@@ -1,28 +1,18 @@
 <?php
 namespace ApacheSolrForTypo3\Tika\Tests\Integration\Service\Tika;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2015 Ingo Renner <ingo@typo3.org>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Tika\Process;
 use ApacheSolrForTypo3\Tika\Service\Tika\ServerService;
@@ -30,14 +20,15 @@ use ApacheSolrForTypo3\Tika\Tests\Integration\Service\Tika\Fixtures\ServerServic
 use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
+use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
-
 /**
  * Class ServerServiceTest
  *
+ * @copyright (c) 2015 Ingo Renner <ingo@typo3.org>
  */
 class ServerServiceTest extends ServiceIntegrationTestCase
 {
@@ -65,6 +56,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
 
         // execute
         $service = new ServerService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->startServer();
 
         // test
@@ -92,6 +84,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
 
         // execute
         $service = new ServerService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->stopServer();
     }
 
@@ -105,6 +98,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
         GeneralUtility::setSingletonInstance(Registry::class, $registryMock->reveal());
 
         $service = new ServerService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $pid = $service->getServerPid();
 
         $this->assertEquals(1000, $pid);
@@ -124,6 +118,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
         GeneralUtility::addInstance(Process::class, $processMock->reveal());
 
         $service = new ServerService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $pid = $service->getServerPid();
 
         $this->assertEquals(1000, $pid);
@@ -139,6 +134,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
         GeneralUtility::setSingletonInstance(Registry::class, $registryMock->reveal());
 
         $service = new ServerService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $this->assertTrue($service->isServerRunning());
     }
 
@@ -156,6 +152,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
         GeneralUtility::addInstance(Process::class, $processMock->reveal());
 
         $service = new ServerService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $this->assertTrue($service->isServerRunning());
     }
 
@@ -173,6 +170,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
         GeneralUtility::addInstance(Process::class, $processMock->reveal());
 
         $service = new ServerService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $this->assertFalse($service->isServerRunning());
     }
 
@@ -183,6 +181,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     {
         $tikaExtensionConfiguration = $this->getConfiguration();
         $service = new ServerService($tikaExtensionConfiguration);
+        $service->setLogger(new NullLogger());
 
         $expectedTikaAuthority = vsprintf(
             '%s://%s:%s',
@@ -201,6 +200,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function extractTextQueriesTikaEndpoint()
     {
         $service = new ServerServiceFixture($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->extractText($this->getMockedFileInstanceForTestWordDotDocFile());
 
         $this->assertEquals('/tika', $service->getRecordedEndpoint());
@@ -212,6 +212,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function extractMetaDataQueriesMetaEndpoint()
     {
         $service = new ServerServiceFixture($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->extractMetaData($this->getMockedFileInstanceForTestWordDotDocFile());
 
         $this->assertEquals('/meta', $service->getRecordedEndpoint());
@@ -223,6 +224,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function detectLanguageFromFileQueriesLanguageStreamEndpoint()
     {
         $service = new ServerServiceFixture($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->detectLanguageFromFile($this->getMockedFileInstanceForTestWordDotDocFile());
 
         $this->assertEquals('/language/stream',
@@ -235,10 +237,11 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function detectLanguageFromStringQueriesLanguageStringEndpoint()
     {
         $service = new ServerServiceFixture($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $service->detectLanguageFromString('foo');
 
         $this->assertEquals(
-            '/language/string', 
+            '/language/string',
             $service->getRecordedEndpoint()
         );
     }
@@ -250,10 +253,12 @@ class ServerServiceTest extends ServiceIntegrationTestCase
      */
     protected function getTikaServerConfiguration()
     {
+        $envVarNamePrefix = 'TESTING_TIKA_';
+
         return [
-            'tikaServerScheme' => 'http',
-            'tikaServerHost' => 'localhost',
-            'tikaServerPort' => '9998'
+            'tikaServerScheme' => getenv($envVarNamePrefix . 'SERVER_SCHEME') ?: 'http',
+            'tikaServerHost' => getenv($envVarNamePrefix . 'SERVER_HOST') ?: 'localhost',
+            'tikaServerPort' => getenv($envVarNamePrefix . 'SERVER_PORT') ?: '9998'
         ];
     }
 
@@ -263,6 +268,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function extractsMetaDataFromDocFile()
     {
         $service = new ServerService($this->getTikaServerConfiguration());
+        $service->setLogger(new NullLogger());
 
         $metaData = $service->extractMetaData($this->getMockedFileInstanceForTestWordDotDocFile());
 
@@ -285,6 +291,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function extractsMetaDataFromMp3File()
     {
         $service = new ServerService($this->getTikaServerConfiguration());
+        $service->setLogger(new NullLogger());
         $fileMock = $this->getMockedFileInstance(
             [
                 'identifier' => 'testMP3.mp3',
@@ -304,6 +311,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function extractsTextFromDocFile()
     {
         $service = new ServerService($this->getTikaServerConfiguration());
+        $service->setLogger(new NullLogger());
 
         $expectedText = 'Sample Word Document';
         $extractedText = $service->extractText($this->getMockedFileInstanceForTestWordDotDocFile());
@@ -317,6 +325,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function extractsTextFromZipFile()
     {
         $service = new ServerService($this->getTikaServerConfiguration());
+        $service->setLogger(new NullLogger());
 
         $expectedTextFromWord = 'Sample Word Document';
         $extractedText = $service->extractText($this->getMockedFileInstance(
@@ -362,6 +371,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function detectsLanguageFromFile($language)
     {
         $service = new ServerService($this->getTikaServerConfiguration());
+        $service->setLogger(new NullLogger());
 
         $detectedLanguage = $service->detectLanguageFromFile(
             $this->getMockedFileInstance(
@@ -383,6 +393,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function detectsLanguageFromString($language)
     {
         $service = new ServerService($this->getTikaServerConfiguration());
+        $service->setLogger(new NullLogger());
 
         $file = $this->testLanguagesPath . $language . '.test';
         $languageString = file_get_contents($file);
@@ -398,6 +409,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function canGetMimeTypesFromServerAndParseThem()
     {
         $service = new ServerService($this->getTikaServerConfiguration());
+        $service->setLogger(new NullLogger());
         $mimeTypes = $service->getSupportedMimeTypes();
         $this->assertContains('application/pdf', $mimeTypes, 'Server did not indicate to support pdf documents');
         $this->assertContains('application/vnd.openxmlformats-officedocument.wordprocessingml.document', $mimeTypes, 'Server did not indicate to support docx documents');
@@ -409,6 +421,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
     public function canPing()
     {
         $service = new ServerService($this->getTikaServerConfiguration());
+        $service->setLogger(new NullLogger());
         $pingResult = $service->ping();
 
         $this->assertTrue($pingResult, 'Could not ping tika server');

--- a/Tests/Integration/Service/Tika/SolrCellServiceTest.php
+++ b/Tests/Integration/Service/Tika/SolrCellServiceTest.php
@@ -1,28 +1,18 @@
 <?php
 namespace ApacheSolrForTypo3\Tika\Tests\Integration\Service\Tika;
 
-/***************************************************************
- *  Copyright notice
+/*
+ * This file is part of the TYPO3 CMS project.
  *
- *  (c) 2015 Ingo Renner <ingo@typo3.org>
- *  All rights reserved
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
  *
- *  This script is part of the TYPO3 project. The TYPO3 project is
- *  free software; you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation; either version 2 of the License, or
- *  (at your option) any later version.
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
  *
- *  The GNU General Public License can be found at
- *  http://www.gnu.org/copyleft/gpl.html.
- *
- *  This script is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
- *
- *  This copyright notice MUST APPEAR in all copies of the script!
- ***************************************************************/
+ * The TYPO3 project - inspiring people to share!
+ */
 
 use ApacheSolrForTypo3\Solr\SolrService;
 use ApacheSolrForTypo3\Solr\System\Solr\Service\SolrWriteService;
@@ -30,6 +20,7 @@ use ApacheSolrForTypo3\Solr\System\Solr\SolrConnection;
 use ApacheSolrForTypo3\Tika\Service\Tika\SolrCellService;
 use Prophecy\Argument;
 use Prophecy\Prophet;
+use Psr\Log\NullLogger;
 use Solarium\QueryType\Extract\Query;
 use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
@@ -37,10 +28,10 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 /**
  * Class AppServiceTest
  *
+ * @copyright (c) 2015 Ingo Renner <ingo@typo3.org>
  */
 class SolrCellServiceTest extends ServiceIntegrationTestCase
 {
-
     /**
      * @var Prophet
      */
@@ -60,6 +51,7 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
     public function newInstancesAreInitializedWithASolrConnection()
     {
         $service = new SolrCellService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $this->assertAttributeInstanceOf(SolrConnection::class, 'solrConnection', $service);
     }
 
@@ -81,6 +73,7 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
         $connectionMock->getWriteService()->shouldBeCalled()->willReturn($solrWriter);
 
         $service = new SolrCellService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $this->inject($service, 'solrConnection', $connectionMock->reveal());
 
         $file = new File(
@@ -107,6 +100,7 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
         $connectionMock->getWriteService()->shouldBeCalled()->willReturn($solrWriter);
 
         $service = new SolrCellService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $this->inject($service, 'solrConnection', $connectionMock->reveal());
 
         $file = new File([
@@ -139,6 +133,7 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
         $connectionMock->getWriteService()->shouldBeCalled()->willReturn($solrWriter);
 
         $service = new SolrCellService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $this->inject($service, 'solrConnection', $connectionMock->reveal());
 
         $file = new File(
@@ -158,6 +153,7 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
     public function extractsMetaDataFromMp3File()
     {
         $service = new SolrCellService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
         $mockedFile = $this->getMockedFileInstance(
             [
                 'identifier' => 'testMP3.mp3',

--- a/Tests/Unit/UnitTestCase.php
+++ b/Tests/Unit/UnitTestCase.php
@@ -47,6 +47,7 @@ class UnitTestCase extends TYPO3UnitTestCase
     {
         $tikaVersion = getenv('TIKA_VERSION') ? getenv('TIKA_VERSION') : '1.24.1';
         $tikaPath = getenv('TIKA_PATH') ? getenv('TIKA_PATH') : '/opt/tika';
+        $envVarNamePrefix = 'TESTING_TIKA_';
 
         return [
             'extractor' => '',
@@ -55,14 +56,19 @@ class UnitTestCase extends TYPO3UnitTestCase
             'tikaPath' => "$tikaPath/tika-app-$tikaVersion.jar",
 
             'tikaServerPath' => "$tikaPath/tika-server-$tikaVersion.jar",
-            'tikaServerScheme' => 'http',
-            'tikaServerHost' => 'localhost',
-            'tikaServerPort' => '9998',
+            'tikaServerScheme' => getenv($envVarNamePrefix . 'SERVER_SCHEME') ?: 'http',
+            'tikaServerHost' => getenv($envVarNamePrefix . 'SERVER_HOST') ?: 'localhost',
+            'tikaServerPort' => getenv($envVarNamePrefix . 'SERVER_PORT') ?: '9998',
 
-            'solrScheme' => 'http',
-            'solrHost' => 'localhost',
-            'solrPort' => '8080',
-            'solrPath' => '/solr/',
+            'solrScheme' => getenv('TESTING_SOLR_SCHEME') ?: 'http',
+            'solrHost' => getenv('TESTING_SOLR_HOST') ?: 'localhost',
+            /*
+             * TODO: The port number differs that is in use for the integration test
+             *       This needs to be checked
+             * @see \ApacheSolrForTypo3\Tika\Tests\Integration\Service\Tika\ServiceIntegrationTestCase::getConfiguration
+             */
+            'solrPort' => getenv('TESTING_SOLR_PORT') ?: 8080,
+            'solrPath' => getenv('TESTING_SOLR_PATH') ?: '/solr/'
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,7 @@
       "dev-master": "6.1.x-dev"
     },
     "typo3/cms": {
-      "extension-key": "apache_solr_for_typo3_sitepackage",
+      "extension-key": "tika",
       "cms-package-dir": "{$vendor-dir}/typo3/cms",
       "web-dir": ".Build/Web"
     }


### PR DESCRIPTION
This pull request replace the use of the LogManager with the LoggerAwareInterface and LoggerAwareTrait.

This allows TYPO3 to inject the required log manager.

The use of numbers for the log severity, replaced with PSR LogLevel constants.
Overall the default log level is now DEBUG.

Additionally the integration and unit tests have been improved to run with the solr-ddev development environment.

Resolves: #137, #160