### PR TITLE
[FEATURE:BP:10] Allow definition of additional Java command options

### DIFF
--- a/Tests/Integration/Service/Tika/AppServiceTest.php
+++ b/Tests/Integration/Service/Tika/AppServiceTest.php
@@ -149,5 +149,15 @@ class AppServiceTest extends ServiceIntegrationTestCase
         $this->assertContains('gzip/document', $supportedMimeTypes, 'Mimetype from alias was not found');
     }
 
+    /**
+     * @test
+     */
+    public function includesAdditionalCommandOptions()
+    {
+        $service = new AppService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
+        $service->getTikaVersion();
+        $this->assertContains('-Dlog4j2.formatMsgNoLookups=\'true\'', ExecRecorder::$execCommand);
+    }
 }
 

--- a/Tests/Integration/Service/Tika/ServiceIntegrationTestCase.php
+++ b/Tests/Integration/Service/Tika/ServiceIntegrationTestCase.php
@@ -295,6 +295,7 @@ abstract class ServiceIntegrationTestCase extends FunctionalTestCase
             'logging' => 0,
 
             'tikaPath' => getenv($envVarNamePrefix . 'APP_JAR_PATH') ?: "$tikaPath/tika-app-$tikaVersion.jar",
+            'javaCommandOptions' => '-Dlog4j2.formatMsgNoLookups=true',
 
             'tikaServerPath' => getenv($envVarNamePrefix . 'SERVER_JAR_PATH') ?: "$tikaPath/tika-server-$tikaVersion.jar",
             'tikaServerScheme' => getenv($envVarNamePrefix . 'SERVER_SCHEME') ?: 'http',

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -21,6 +21,9 @@ fileSizeLimit = 500
 #  cat=jar//10; type=string; label=Tika App Jar Path: The absolute path to your Apache Tika app jar file (tika-app-x.x.jar)
 tikaPath =
 
+#  cat=jar//20; type=string; label=Java command options: Additional command options passed to the java executable (only -D parameter is supported). Separate multiple parameters with a space.
+javaCommandOptions =
+
 #  cat=server//10; type=string; label=Tika Server Jar Path: [Optional] The absolute path to your Apache Tika server jar file (tika-server-x.x.jar). When set you can use the backend module to start and stop the Tika server from the TYPO3 backend. Otherwise the host and port settings will be used.
 tikaServerPath =
 


### PR DESCRIPTION
**Backport of #172 for 10.0.x**

---

This commit introduces the ability to provide additional command options. They are passed to the Java command when using the tika app. For safety reasons, only a small subset of command options can be configured:

* `-Dfoo=bar`
* `-Dfoo='hello world'`
* `-Dfoo="hello world"`

The command options can be configured via extension configuration `javaCommandOptions`.