### PR TITLE
[FEATURE:BP:6] Allow definition of additional Java command options

### DIFF
--- a/Classes/Service/Tika/AppService.php
+++ b/Classes/Service/Tika/AppService.php
@@ -38,6 +38,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class AppService extends AbstractService
 {
+    protected const JAVA_COMMAND_OPTIONS_REGEX = '/-D(?P<property>[\w.]+)=(?P<value>"[^"]+"|\'[^\']+\'|[^\\s\'"]+)/';
+
     /**
     * @var array
     */
@@ -72,6 +74,7 @@ class AppService extends AbstractService
     {
         $tikaCommand = CommandUtility::getCommand('java')
             . ' -Dfile.encoding=UTF8' // forces UTF8 output
+            . $this->getAdditionalCommandOptions()
             . ' -jar ' . escapeshellarg(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']))
             . ' -V';
 
@@ -90,6 +93,7 @@ class AppService extends AbstractService
         $tikaCommand = ShellUtility::getLanguagePrefix()
             . CommandUtility::getCommand('java')
             . ' -Dfile.encoding=UTF8' // forces UTF8 output
+            . $this->getAdditionalCommandOptions()
             . ' -jar ' . escapeshellarg(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']))
             . ' -t'
             . ' ' . ShellUtility::escapeShellArgument($localTempFilePath);
@@ -117,6 +121,7 @@ class AppService extends AbstractService
         $tikaCommand = ShellUtility::getLanguagePrefix()
             . CommandUtility::getCommand('java')
             . ' -Dfile.encoding=UTF8'
+            . $this->getAdditionalCommandOptions()
             . ' -jar ' . escapeshellarg(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']))
             . ' -m'
             . ' ' . ShellUtility::escapeShellArgument($localTempFilePath);
@@ -179,6 +184,7 @@ class AppService extends AbstractService
         $tikaCommand = ShellUtility::getLanguagePrefix()
             . CommandUtility::getCommand('java')
             . ' -Dfile.encoding=UTF8'
+            . $this->getAdditionalCommandOptions()
             . ' -jar ' . escapeshellarg(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']))
             . ' -l'
             . ' ' . ShellUtility::escapeShellArgument($localFilePath);
@@ -311,7 +317,46 @@ class AppService extends AbstractService
      */
     protected function getMimeTypeOutputFromTikaJar(): string
     {
-        $tikaCommand = ShellUtility::getLanguagePrefix() . CommandUtility::getCommand('java') . ' -Dfile.encoding=UTF8' . ' -jar ' . escapeshellarg(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath'])) . ' --list-supported-types';
+        $tikaCommand = ShellUtility::getLanguagePrefix()
+            . CommandUtility::getCommand('java')
+            . ' -Dfile.encoding=UTF8'
+            . $this->getAdditionalCommandOptions()
+            . ' -jar ' . escapeshellarg(FileUtility::getAbsoluteFilePath($this->configuration['tikaPath']))
+            . ' --list-supported-types';
+
         return trim(shell_exec($tikaCommand));
+    }
+
+    /**
+     * Parse additional Java command options.
+     *
+     * Reads the configuration value `javaCommandOptions` and tries to parse it to a
+     * safe argument string. For safety reasons, only the following variants are
+     * allowed (multiple separated by space):
+     *
+     * -Dfoo=bar
+     * -Dfoo='hello world'
+     * -Dfoo="hello world"
+     *
+     * @return string Parsed additional Java command options
+     */
+    protected function getAdditionalCommandOptions(): string
+    {
+        $commandOptions = trim((string)($this->configuration['javaCommandOptions'] ?? ''));
+
+        // Early return if no additional command options are configured
+        // or configuration does not match required pattern (only -D parameter is supported)
+        if ('' === $commandOptions || !preg_match_all(self::JAVA_COMMAND_OPTIONS_REGEX, $commandOptions, $matches)) {
+            return '';
+        }
+
+        // Combine matched command options with escaped argument value
+        $commandOptionsString = '';
+        foreach (array_combine($matches['property'], $matches['value']) as $property => $unescapedValue) {
+            $escapedValue = CommandUtility::escapeShellArgument(trim($unescapedValue, '"\''));
+            $commandOptionsString .= sprintf(' -D%s=%s', $property, $escapedValue);
+        }
+
+        return $commandOptionsString;
     }
 }

--- a/Tests/Integration/Service/Tika/AppServiceTest.php
+++ b/Tests/Integration/Service/Tika/AppServiceTest.php
@@ -157,7 +157,6 @@ class AppServiceTest extends ServiceIntegrationTestCase
     public function includesAdditionalCommandOptions()
     {
         $service = new AppService($this->getConfiguration());
-        $service->setLogger(new NullLogger());
         $service->getTikaVersion();
         $this->assertContains('-Dlog4j2.formatMsgNoLookups=\'true\'', ExecRecorder::$execCommand);
     }

--- a/Tests/Integration/Service/Tika/AppServiceTest.php
+++ b/Tests/Integration/Service/Tika/AppServiceTest.php
@@ -151,5 +151,15 @@ class AppServiceTest extends ServiceIntegrationTestCase
         $this->assertContains('gzip/document', $supportedMimeTypes, 'Mimetype from alias was not found');
     }
 
+    /**
+     * @test
+     */
+    public function includesAdditionalCommandOptions()
+    {
+        $service = new AppService($this->getConfiguration());
+        $service->setLogger(new NullLogger());
+        $service->getTikaVersion();
+        $this->assertContains('-Dlog4j2.formatMsgNoLookups=\'true\'', ExecRecorder::$execCommand);
+    }
 }
 

--- a/Tests/Integration/Service/Tika/ServiceIntegrationTestCase.php
+++ b/Tests/Integration/Service/Tika/ServiceIntegrationTestCase.php
@@ -295,6 +295,7 @@ abstract class ServiceIntegrationTestCase extends FunctionalTestCase
             'logging' => 0,
 
             'tikaPath' => getenv($envVarNamePrefix . 'APP_JAR_PATH') ?: "$tikaPath/tika-app-$tikaVersion.jar",
+            'javaCommandOptions' => '-Dlog4j2.formatMsgNoLookups=true',
 
             'tikaServerPath' => getenv($envVarNamePrefix . 'SERVER_JAR_PATH') ?: "$tikaPath/tika-server-$tikaVersion.jar",
             'tikaServerScheme' => getenv($envVarNamePrefix . 'SERVER_SCHEME') ?: 'http',

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -22,6 +22,9 @@ fileSizeLimit = 500
 #  cat=jar//10; type=string; label=Tika App Jar Path: The absolute path to your Apache Tika app jar file (tika-app-x.x.jar)
 tikaPath =
 
+#  cat=jar//20; type=string; label=Java command options: Additional command options passed to the java executable (only -D parameter is supported). Separate multiple parameters with a space.
+javaCommandOptions =
+
 #  cat=server//10; type=string; label=Tika Server Jar Path: [Optional] The absolute path to your Apache Tika server jar file (tika-server-x.x.jar). When set you can use the backend module to start and stop the Tika server from the TYPO3 backend. Otherwise the host and port settings will be used.
 tikaServerPath =
 


### PR DESCRIPTION
**Backport of #172 for 6.0.x**

---

This commit introduces the ability to provide additional command options. They are passed to the Java command when using the tika app. For safety reasons, only a small subset of command options can be configured:

* `-Dfoo=bar`
* `-Dfoo='hello world'`
* `-Dfoo="hello world"`

The command options can be configured via extension configuration `javaCommandOptions`.