### PR TITLE
[BUGFIX] Handle custom java command options for server module as well

### DIFF
--- a/Classes/Service/Tika/AppService.php
+++ b/Classes/Service/Tika/AppService.php
@@ -28,8 +28,6 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 class AppService extends AbstractService
 {
-    protected const JAVA_COMMAND_OPTIONS_REGEX = '/-D(?P<property>[\w.]+)=(?P<value>"[^"]+"|\'[^\']+\'|[^\\s\'"]+)/';
-
     /**
     * @var array
     */
@@ -324,38 +322,5 @@ class AppService extends AbstractService
             . ' --list-supported-types';
 
         return trim(shell_exec($tikaCommand));
-    }
-
-    /**
-     * Parse additional Java command options.
-     *
-     * Reads the configuration value `javaCommandOptions` and tries to parse it to a
-     * safe argument string. For safety reasons, only the following variants are
-     * allowed (multiple separated by space):
-     *
-     * -Dfoo=bar
-     * -Dfoo='hello world'
-     * -Dfoo="hello world"
-     *
-     * @return string Parsed additional Java command options
-     */
-    protected function getAdditionalCommandOptions(): string
-    {
-        $commandOptions = trim((string)($this->configuration['javaCommandOptions'] ?? ''));
-
-        // Early return if no additional command options are configured
-        // or configuration does not match required pattern (only -D parameter is supported)
-        if ('' === $commandOptions || !preg_match_all(self::JAVA_COMMAND_OPTIONS_REGEX, $commandOptions, $matches)) {
-            return '';
-        }
-
-        // Combine matched command options with escaped argument value
-        $commandOptionsString = '';
-        foreach (array_combine($matches['property'], $matches['value']) as $property => $unescapedValue) {
-            $escapedValue = CommandUtility::escapeShellArgument(trim($unescapedValue, '"\''));
-            $commandOptionsString .= sprintf(' -D%s=%s', $property, $escapedValue);
-        }
-
-        return $commandOptionsString;
     }
 }

--- a/Classes/Service/Tika/ServerService.php
+++ b/Classes/Service/Tika/ServerService.php
@@ -94,6 +94,8 @@ class ServerService extends AbstractService
      */
     protected function getProcess($arguments = ''): Process
     {
+        $arguments = trim($this->getAdditionalCommandOptions() . ' ' . $arguments);
+
         return GeneralUtility::makeInstance(Process::class, CommandUtility::getCommand('java'), $arguments);
     }
 


### PR DESCRIPTION
This PR is a follow-up to #172.

---

In #172, the possibility to define custom java command options has been added. However, this was only provided for the Tika app. When using a Tika server module, direct calls to the `java` executable are triggered as well, therefore the custom command options are now applied there as well.