### PR TITLE
[TASK] Fix TYPO3 coding standards differences between PHP versions

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -3,7 +3,16 @@
 declare(strict_types=1);
 
 $config = \TYPO3\CodingStandards\CsFixerConfig::create();
-$config->getFinder()
+$config
+    ->addRules(
+        [
+            'ordered_imports' => [
+                'imports_order' => ['class', 'function', 'const'],
+                'sort_algorithm' => 'alpha'
+            ]
+        ],
+    )
+    ->getFinder()
     ->exclude([
         '.Build'
     ])

--- a/Classes/Service/Tika/ServerService.php
+++ b/Classes/Service/Tika/ServerService.php
@@ -27,7 +27,6 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LogLevel;
-use function str_starts_with;
 use Throwable;
 use TYPO3\CMS\Core\Http\RequestFactory;
 use TYPO3\CMS\Core\Http\Stream;
@@ -36,6 +35,8 @@ use TYPO3\CMS\Core\Registry;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Utility\CommandUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function str_starts_with;
 
 /**
  * A Tika service implementation using the tika-server.jar

--- a/Tests/Integration/Service/Tika/ServiceIntegrationTestCase.php
+++ b/Tests/Integration/Service/Tika/ServiceIntegrationTestCase.php
@@ -17,7 +17,6 @@ namespace ApacheSolrForTypo3\Tika\Tests\Integration\Service\Tika;
  * The TYPO3 project - inspiring people to share!
  */
 
-use function getenv;
 use InvalidArgumentException;
 use PHPUnit\Framework\MockObject\MockObject;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -35,6 +34,8 @@ use TYPO3\CMS\Core\Resource\ResourceStorage;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+use function getenv;
 
 /**
  * Base class for EXT:tika tests

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
     "phpspec/prophecy-phpunit":"*",
     "typo3/testing-framework": "^6.12",
     "apache-solr-for-typo3/solr": "dev-release-11.5.x",
-    "typo3/coding-standards": ">=0.5.0",
+    "typo3/coding-standards": "~0.6.1",
     "typo3/tailor": "^1.4"
   },
   "suggest": {
@@ -88,7 +88,10 @@
       "@composer req --prefer-source --update-with-all-dependencies typo3/cms-core:11.5.x-dev"
     ],
     "tests:unit": [ "phpunit --colors -c Build/Test/UnitTests.xml --bootstrap=Build/Test/UnitTestsBootstrap.php" ],
-    "tests:integration": [ "phpunit --colors -c Build/Test/IntegrationTests.xml --bootstrap=Build/Test/IntegrationTestsBootstrap.php" ]
+    "tests:integration": [ "phpunit --colors -c Build/Test/IntegrationTests.xml --bootstrap=Build/Test/IntegrationTestsBootstrap.php" ],
+    "t3:standards:fix": [
+      "php-cs-fixer fix"
+    ]
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION
This change contains: 

* The PSR12 rule for import type blocks for PhpcsFixer  The ordered_imports.imports_order is now  class, function, const
* the coding standards fixes for TYPO3 12+ as well.