### PR TITLE
Release 12.0.1

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -28,10 +28,10 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots to help explain your problem.
 
 **Used versions (please complete the following information):**
- - TYPO3 Version: [e.g. 12.0.0]
+ - TYPO3 Version: [e.g. 12.4.7]
  - Browser: [e.g. chrome, safari]
- - EXT:solr Version: [e.g. 12.0.0]
- - EXT:tika Version: [e.g. 12.0.0]
+ - EXT:solr Version: [e.g. 12.0.x]
+ - EXT:tika Version: [e.g. 12.0.1]
  - Used Apache Solr Version: [e.g. 9.3.0]
  - PHP Version: [e.g. 8.1.0]
  - MySQL Version: [e.g. 8.0.0]

--- a/Documentation/Releases/12_0.rst
+++ b/Documentation/Releases/12_0.rst
@@ -2,6 +2,52 @@
 ..  index:: Releases
 ..  _releases-tika-12_0:
 
+
+==============
+Release 12.0.1
+==============
+
+This release is relevant for Apache Solr Cell/server users only. To be able to use Apache Solr server as extractor.
+
+Important for Solr Cell users
+-----------------------------
+
+- !!![BUGFIX] SolrCell broken due of EXT:solr BC change on connection conf `cdd7134 on @2023-10-19 <https://github.com/TYPO3-Solr/ext-tika/commit/cdd7134>`_ (thanks to Rafael Kähm)
+
+EXT:solr 12.0.0 requires separate configurations for
+:php:`path` + :php:`core` and :php:`username` + :php:`password`.
+All this settings must be given separately now.
+The :php:`path` setting is handled the same way as in EXT:solr also:
+
+     Must not contain "/solr/"! Unless you have an additional "solr" segment in your path like "http://localhost:8983/solr/solr/core_en".
+
+
+.. tip::
+
+       All settings of Solr accept the :php:`%env(<SOME_SOLR_ENV_VAR>)%` syntax like on site-config now.
+
+       If the settings for :php:`solrUsername` or :php:`solrPassword` do not contain the :php:`%env(<SOME_SOLR_ENV_VAR>)%`,
+       then they are blinded, to avoid the accidental release of secrets and credentials via TYPO3 backend configuration Tools like:
+
+       * Extension Settings module
+       * Configuration module
+
+
+..  figure:: /Images/BE_Settings_ExtensionConfiguration_Solr.png
+    :class: with-shadow
+    :alt: Extension configuration for EXT:tika - Solr Cell configuration
+
+    Extension configuration for EXT:tika - Solr Cell configuration
+
+All other changes
+~~~~~~~~~~~~~~~~~
+
+- [TASK] Fix PHP-CS for single_line_empty_body rule `73e17bb on @2023-09-22 <https://github.com/TYPO3-Solr/ext-tika/commit/73e17bb>`_ (thanks to Rafael Kähm)
+- [BUGFIX] Actions replace LOCAL_VOLUME_NAME with SOLR_VOLUME_NAME `86ce68a on @2023-09-22 <https://github.com/TYPO3-Solr/ext-tika/commit/86ce68a>`_ (thanks to Rafael Kähm)
+- [BUGFIX] Remove debug logging from Reports and print the troubles directly `1a2a8ec on @2023-10-19 <https://github.com/TYPO3-Solr/ext-tika/commit/1a2a8ec>`_ (thanks to Rafael Kähm)
+- [FEATURE] Blind the Solr Cell crendetials in TYPO3 configuration tools `6618965 on @2023-10-19 <https://github.com/TYPO3-Solr/ext-tika/commit/6618965>`_ (thanks to Rafael Kähm)
+- [DOC] reafactor the docs `c899cf8 on @2023-10-19 <https://github.com/TYPO3-Solr/ext-tika/commit/c899cf8>`_ (thanks to Rafael Kähm)
+
 ==============
 Release 12.0.0
 ==============

--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -1,8 +1,8 @@
 [general]
 
 project     = Apache Tika for TYPO3
-version     = 12.0.0
-release     = 12.0.0
+version     = 12.0.1
+release     = 12.0.1
 t3author    = Ingo Renner, Timo Hund, dkd and contributors
 copyright   = since 2009 by dkd & contributors
 

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,7 +4,7 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Tika for TYPO3',
     'description' => 'Provides Tika services for TYPO3 to detect a document\'s language, extract meta data, and extract content from files. Can either use a stand alone Tika executable or Tika integrated in a Solr server with an activated extracting request handler.',
-    'version' => '12.0.0',
+    'version' => '12.0.1',
     'state' => 'stable',
     'category' => 'services',
     'author' => 'Ingo Renner, Timo Hund, Markus Friedrich, Rafael Kähm',


### PR DESCRIPTION
# Apache Solr for TYPO3 - Tika Addon version 12.0.1

**Note:** 
This release is especially relevant for Apache Solr Cell/server users. To be able to use Apache Solr server as extractor, the Solr "path", "port", and if used the "username" and "passord" must be adjusted.

# Please read the release notes for more information:

* https://github.com/TYPO3-Solr/ext-tika/releases/tag/12.0.1
* https://docs.typo3.org/p/apache-solr-for-typo3/tika/12.0/en-us/Releases/12_0.html

---

# How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on [GitHub](https://github.com/TYPO3-Solr/ext-solr)
* Ask or help or answer questions in our [Slack channel](https://typo3.slack.com/messages/ext-solr/)
* Provide patches through Pull Request or review and comment on existing [Pull Requests](https://github.com/TYPO3-Solr/ext-solr/pulls)
* Go to [www.typo3-solr.com](http://www.typo3-solr.com) or call [dkd](http://www.dkd.de) to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:

http://www.typo3-solr.com/en/contact/

or call:

+49 (0)69 - 2475218 0