### PR TITLE
[DOCS] Fix repository URL in documentation

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -9,14 +9,14 @@ copyright   = since 2009 by dkd & contributors
 [html_theme_options]
 
 # "Edit on GitHub" button
-github_repository    = TYPO3-Solr/ext-solr
+github_repository    = TYPO3-Solr/ext-tika
 github_branch        = main
 
 # Footer links
 project_home         = https://www.typo3-solr.com
 project_contact      = solr-eb-support@dkd.de
-project_repository   = https://github.com/TYPO3-Solr/ext-solr
-project_issues       = https://github.com/TYPO3-Solr/ext-solr/issues
+project_repository   = https://github.com/TYPO3-Solr/ext-tika
+project_issues       = https://github.com/TYPO3-Solr/ext-tika/issues
 project_discussions  = https://typo3.slack.com/archives/C02FF05Q4
 
 use_opensearch       =


### PR DESCRIPTION
This PR fixes the repository URL in the documentation as it was set to https://github.com/TYPO3-Solr/ext-solr instead of https://github.com/TYPO3-Solr/ext-tika.