### PR TITLE
[FIX] TIKA-Preview does not work on TYPO3 13.4+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         PHP: [ '8.2', '8.3' ]
-        TYPO3: [ 'dev-main' ]
+        TYPO3: [ '^13.4', '13.4.x-dev' ]
     env:
       typo3DatabaseName: 'typo3_ci'
       typo3DatabaseHost: '127.0.0.1'

--- a/Classes/ViewHelpers/Backend/IsStringViewHelper.php
+++ b/Classes/ViewHelpers/Backend/IsStringViewHelper.php
@@ -17,6 +17,7 @@ declare(strict_types=1);
 
 namespace ApacheSolrForTypo3\Tika\ViewHelpers\Backend;
 
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
 
 /**
@@ -37,15 +38,7 @@ class IsStringViewHelper extends AbstractConditionViewHelper
         $this->registerArgument('value', 'mixed', 'Value to be verified.', true);
     }
 
-    /**
-     * This method decides if the condition is true or false
-     *
-     * @param array $arguments ViewHelper arguments to evaluate the condition for this ViewHelper.
-     *
-     * @noinspection PhpMissingReturnTypeInspection
-     * @noinspection PhpUnused
-     */
-    protected static function evaluateCondition($arguments = null)
+    public static function verdict(array $arguments, RenderingContextInterface $renderingContext): bool
     {
         return is_string($arguments['value'] ?? null);
     }

--- a/Resources/Public/JavaScript/ContextMenuActions.js
+++ b/Resources/Public/JavaScript/ContextMenuActions.js
@@ -4,12 +4,12 @@ import $ from 'jquery';
 class ContextMenuActions {
 
 
-  tikaPreview = function (table, uid) {
+  tikaPreview = function (table, uid, dataAttributes) {
     if (table === 'sys_file') {
 
       const configuration = {
         title: 'Tika Preview',
-        content:  $(this).data('action-url') + '&identifier=' + encodeURIComponent(uid).replace(/\*/g, '%2A'),
+        content:  dataAttributes.actionUrl + '&identifier=' + encodeURIComponent(uid).replace(/\*/g, '%2A'),
         size: Modal.sizes.large,
         type: Modal.types.ajax
       };

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
   "require": {
     "php": "^8.2",
     "ext-json": "*",
-    "typo3/cms-backend": "^v13.1",
-    "typo3/cms-core": "^v13.1",
-    "typo3/cms-extbase": "^v13.1",
-    "typo3/cms-filemetadata": "^v13.1",
-    "typo3/cms-fluid": "^v13.1",
-    "typo3/cms-reports": "^v13.1"
+    "typo3/cms-backend": "^v13.4.0",
+    "typo3/cms-core": "^v13.4.0",
+    "typo3/cms-extbase": "^v13.4.0",
+    "typo3/cms-filemetadata": "^v13.4.0",
+    "typo3/cms-fluid": "^v13.4.0",
+    "typo3/cms-reports": "^v13.4.0"
   },
   "require-dev": {
     "apache-solr-for-typo3/solr": "13.0.x-dev",
@@ -41,7 +41,7 @@
     "sclable/xml-lint": "^0.8.0",
     "typo3/cms-lowlevel": "*",
     "typo3/coding-standards": "v0.8.0",
-    "typo3/testing-framework": "dev-main#47bf0daab24b4210221f46a1fde59b9c3e245e39 as 9.0"
+    "typo3/testing-framework": "^9.0.1"
   },
   "suggest": {
     "apache-solr-for-typo3/solr": "Allows to use Solr Cell - Apache Tika embedded in Apache Solr.",


### PR DESCRIPTION
* Migrate ContextMenuActions.js to non jQuery version.
* Migrate to Fluid 4+

Fixes: #234