### PR TITLE
Release 13.0.0

### DIFF
--- a/Documentation/Releases/13_0.rst
+++ b/Documentation/Releases/13_0.rst
@@ -5,33 +5,32 @@
 Releases 13.0
 =============
 
-We are happy to announce version 13.0.0 of EXT:tika.
-
-**Important**: This version is compatible with 13 LTS only.
-
-All changes since alpha-1:
---------------------------
-
-
-
-Release 13.0.0-alpha-1
-======================
-
-This is a first alpha release for upcoming TYPO3 13 LTS
+We are happy to announce new major version 13.0 of EXT:tika for TYPO3 13 LTS.
 
 All changes:
 ------------
 
-*   [TASK] Prepare main branch for TYPO3 13 by @dkd-kaehm
-*   [TASK] Update to typo3/coding-standards v0.8.0 by @dkd-friedrich
-*   [TASK] Update PHPUnit and testing framework by @dkd-friedrich
-*   [TASK] Update dependencies for TYPO3 13.0.x by @dkd-friedrich
+- [TASK] Prepare main branch for TYPO3 13 by Rafael Kähm `(5a6aad1) <https://github.com/TYPO3-Solr/ext-tika/commit/5a6aad1>`_
+- [TASK] Update to typo3/coding-standards v0.8.0 by Markus Friedrich `(4db9ed9) <https://github.com/TYPO3-Solr/ext-tika/commit/4db9ed9>`_
+- [TASK] Update PHPUnit and testing framework by Markus Friedrich `(e38da56) <https://github.com/TYPO3-Solr/ext-tika/commit/e38da56>`_
+- [TASK] Update dependencies for TYPO3 13.0.x by Markus Friedrich `(3a7fe80) <https://github.com/TYPO3-Solr/ext-tika/commit/3a7fe80>`_
+- [TASK] Replace cibuild.sh by Markus Friedrich `(53bba67) <https://github.com/TYPO3-Solr/ext-tika/commit/53bba67>`_
+- [RELEASE] 13.0.0-alpha-1 by Markus Friedrich `(009e383) <https://github.com/TYPO3-Solr/ext-tika/commit/009e383>`_
+- [FIX] Set composer dependencies properly by Rafael Kähm `(9fcfa46) <https://github.com/TYPO3-Solr/ext-tika/commit/9fcfa46>`_
+- [FIX] TIKA-Preview does not work on TYPO3 13.4+ by Rafael Kähm `(3efbdc2) <https://github.com/TYPO3-Solr/ext-tika/commit/3efbdc2>`_
+- [TASK] Sync with EXT:solr dev-main by Rafael Kähm `(bb41a6f) <https://github.com/TYPO3-Solr/ext-tika/commit/bb41a6f>`_
+- [TASK] Simplify EXT:solr tests stack by Rafael Kähm `(a0571ad) <https://github.com/TYPO3-Solr/ext-tika/commit/a0571ad>`_
+- [TASK] Extract sclable/xml-lint to global by Rafael Kähm `(09b5f10) <https://github.com/TYPO3-Solr/ext-tika/commit/09b5f10>`_
+- [TASK] run static analysis checks on TYPO3 majors min. PHP vers. by Rafael Kähm `(0f88385) <https://github.com/TYPO3-Solr/ext-tika/commit/0f88385>`_
+- [TASK] Remove Implicitly nullable parameter declarations deprecated by Thomas Hohn `(d6687e0) <https://github.com/TYPO3-Solr/ext-tika/commit/d6687e0>`_
+- [DOCS] Migrate Documentation to the new rendering by Rafael Kähm `(70f3191) <https://github.com/TYPO3-Solr/ext-tika/commit/70f3191>`_
 
 Contributors
 ------------
 
 *   Markus Friedrich
 *   Rafael Kähm
+*   Thomas Hohn
 
 Thanks to everyone who helped in creating this release!
 

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -19,8 +19,8 @@
   />
   <project
 	  title="Apache Tika for TYPO3"
-	  release="13.0.0-alpha-1"
-	  version="13.0.0"
+	  release="13.0"
+	  version="13.0"
 	  copyright="since 2009 by dkd &amp; contributors"
   />
 </guides>

--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,12 @@
   "require": {
     "php": "^8.2",
     "ext-json": "*",
-    "typo3/cms-backend": "^v13.4.0",
-    "typo3/cms-core": "^v13.4.0",
-    "typo3/cms-extbase": "^v13.4.0",
-    "typo3/cms-filemetadata": "^v13.4.0",
-    "typo3/cms-fluid": "^v13.4.0",
-    "typo3/cms-reports": "^v13.4.0"
+    "typo3/cms-backend": "*",
+    "typo3/cms-core": "^v13.4.2",
+    "typo3/cms-extbase": "*",
+    "typo3/cms-filemetadata": "*",
+    "typo3/cms-fluid": "*",
+    "typo3/cms-reports": "*"
   },
   "require-dev": {
     "apache-solr-for-typo3/solr": "13.0.x-dev",

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -4,15 +4,15 @@
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Apache Tika for TYPO3',
     'description' => 'Provides Tika services for TYPO3 to detect a document\'s language, extract meta data, and extract content from files. Can either use a stand alone Tika executable or Tika integrated in a Solr server with an activated extracting request handler.',
-    'version' => '13.0.0-alpha-1',
-    'state' => 'alpha',
+    'version' => '13.0.0',
+    'state' => 'stable',
     'category' => 'services',
     'author' => 'Ingo Renner, Timo Hund, Markus Friedrich, Rafael Kähm',
     'author_email' => 'solr-eb-support@dkd.de',
     'author_company' => 'dkd Internet Service GmbH',
     'constraints' => [
         'depends' => [
-            'typo3' => '13.1.0-13.4.99',
+            'typo3' => '13.4.2-13.4.99',
             'filemetadata' => '',
         ],
         'conflicts' => [],


### PR DESCRIPTION
# Apache Solr for TYPO3 - Tika Addon version 13.0.0

**Important**: 
* This version is compatible with TYPO3 13 LTS only.
* This release requires TIKA Server v1.28 or Apache Solr 9.7.0+ as extractor services.

# Please read the release notes before updating:

https://github.com/TYPO3-Solr/ext-tika/releases/tag/13.0.0

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0

Fixes: #241