### PR TITLE
Add Index.html and Preview.html in Default for Typo3 backend

### DIFF
--- a/Resources/Private/Templates/Default/Index.html
+++ b/Resources/Private/Templates/Default/Index.html
@@ -1,0 +1,71 @@
+
+<div xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+	xmlns:solr="http://typo3.org/ns/ApacheSolrForTypo3/Solr/ViewHelpers"
+	f:schemaLocation="https://fluidtypo3.org/schemas/fluid-master.xsd">
+	<f:render partial="FlashMessages" />
+
+	<f:be.infobox title="Caution" state="1">
+		This module is still experimental and is supposed to work with Tika Server only for now.
+	</f:be.infobox>
+
+	<p>
+		Tika Mode:
+		<f:switch expression="{configuration.extractor}">
+			<f:case value="server">Tika Server</f:case>
+			<f:case value="jar">Tika App {jar.version}</f:case>
+			<f:case value="solr">Solr Server</f:case>
+		</f:switch>
+	</p>
+
+	<f:if condition="{configuration.extractor} != 'solr'">
+		<p>
+		Tika App Jar: {configuration.tikaPath}
+		</p>
+		<p>
+		Tika Server Jar: {configuration.tikaServerPath}
+		</p>
+	</f:if>
+
+	<f:if condition="{configuration.extractor} == 'server'">
+		<!-- // TODO use partial -->
+		<p>
+		Tika Server status (PID): {f:if(condition: '{server.pid} > 0', then: 'running (pid: {server.pid})', else: 'server pid not found')}
+		</p>
+		<p>
+		Tika Server status (ping): {f:if(condition: '{server.isRunning}', then: 'running', else: 'stopped')}
+		</p>
+
+
+		<f:if condition="{server.isRunning}">
+			<f:then>
+				<p>
+				Tika is running.<br />
+				Version: {server.version}<br />
+
+				<f:if condition="{server.isControllable}">
+					Tika can be controlled. PID: {server.pid}
+					<f:form action="stopServer" method="POST">
+						<f:form.submit class="btn btn-sm btn-default" value="Stop Tika Server"/>
+					</f:form>
+				</f:if>
+				</p>
+			</f:then>
+			<f:else>
+				<p>
+				Tika is stopped.
+
+				<f:if condition="{server.isControllable}">
+					Tika can be controlled.
+					<f:form action="startServer" method="POST">
+						<f:form.submit class="btn btn-sm btn-default" value="Start Tika Server"/>
+					</f:form>
+				</f:if>
+				</p>
+			</f:else>
+		</f:if>
+
+	</f:if>
+
+
+
+</div>

--- a/Resources/Private/Templates/Default/Preview.html
+++ b/Resources/Private/Templates/Default/Preview.html
@@ -1,0 +1,53 @@
+<div xmlns:f="http://typo3.org/ns/TYPO3/Fluid/ViewHelpers"
+     xmlns:tika="http://typo3.org/ns/ApacheSolrForTypo3/Tika/ViewHelpers/Backend"
+     f:schemaLocation="https://fluidtypo3.org/schemas/fluid-master.xsd">
+
+    <div>
+        <h4>Extracted content:</h4>
+        <f:if condition="{content}">
+            <pre style="height: 20em; width:100%; max-width: 1000px; overflow:scroll;">{content}</pre>
+        </f:if>
+        <table class="table table-bordered table-striped">
+            <thead>
+            <tr>
+                <th scope="col">Key</th>
+                <th scope="col">Value</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+                <th>Detected Language:</th>
+                <td>{language}</td>
+            </tr>
+            <f:render section="Rows" arguments="{tableRows: metadata}"/>
+            </tbody>
+        </table>
+    </div>
+</div>
+
+<f:section name="Rows">
+    <f:for each="{tableRows}" key="tableRowFiledName" as="tableRowValue" >
+        <tr>
+            <th scope="row">{tableRowFiledName}</th>
+            <tika:isString value="{tableRowValue}">
+                <f:then>
+                    <td>{tableRowValue}</td>
+                </f:then>
+                <f:else>
+                    <td>
+                        <f:render section="SubTable" arguments="{tableRows: tableRowValue}"/>
+                    </td>
+                </f:else>
+            </tika:isString>
+        </tr>
+    </f:for>
+</f:section>
+
+<f:section name="SubTable">
+    <table class="table table-condensed table-hover table-striped table-bordered">
+        <thead><tr><th>Key</th> <th>Value</th></tr></thead>
+        <tbody>
+        <f:render section="Rows" arguments="{tableRows: tableRows}"/>
+        </tbody>
+    </table>
+</f:section>


### PR DESCRIPTION
TYPO3 13 changed the way backend templates are resolved.
In TYPO3 12, the extension correctly found templates in their subfolders (e.g., TKControlPanelModule/SolarModule).
In TYPO3 13, the same setup causes a "Default/Index.html" lookup error.

To fix this for TYPO3 13 without breaking existing functionality:
- Added Index.html and Preview.html to the Default/ folder.

This ensures that the backend modules can render properly, while keeping the original structure intact.
Maintainers can review and decide if this approach should be applied in the main branch permanently or if a more structured solution is needed in the future.
