### PR TITLE
[DOCS] Apache Solr 9.10.0 CELL does not extract metadata from binaries properly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,7 @@ jobs:
     name: Publish new version to TER
     needs: tests
     if: startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       TYPO3_API_TOKEN: ${{ secrets.TYPO3_API_TOKEN }}
 

--- a/Classes/Controller/Backend/PreviewController.php
+++ b/Classes/Controller/Backend/PreviewController.php
@@ -57,17 +57,17 @@ class PreviewController
         $tikaService = $this->getConfiguredTikaService();
         $metadata = $tikaService->extractMetaData(
             /** not real static-analysis error, because checked in {@link \ApacheSolrForTypo3\Tika\ContextMenu\Preview::canHandle()} */
-            $file
+            $file,
         );
         $content = $tikaService->extractText(
             /** not real static-analysis error, because checked in {@link \ApacheSolrForTypo3\Tika\ContextMenu\Preview::canHandle()} */
-            $file
+            $file,
         );
 
         try {
             $language = $tikaService->detectLanguageFromFile(
                 /** not real static-analysis error, because checked in {@link \ApacheSolrForTypo3\Tika\ContextMenu\Preview::canHandle()} */
-                $file
+                $file,
             );
         } catch (Throwable) {
             $language = 'not detectable';

--- a/Classes/Controller/Backend/SolrModule/TikaControlPanelModuleController.php
+++ b/Classes/Controller/Backend/SolrModule/TikaControlPanelModuleController.php
@@ -95,7 +95,7 @@ class TikaControlPanelModuleController extends AbstractModuleController
         $this->moduleTemplate->assign('configuration', $this->tikaConfiguration);
         $this->moduleTemplate->assign(
             'extractor',
-            ucfirst($this->tikaConfiguration['extractor'] ?? '')
+            ucfirst($this->tikaConfiguration['extractor'] ?? ''),
         );
 
         switch ($this->tikaConfiguration['extractor']) {
@@ -109,7 +109,7 @@ class TikaControlPanelModuleController extends AbstractModuleController
                         'isControllable' => $this->isTikaServerControllable(),
                         'pid' => $this->getTikaServerPid(),
                         'version' => $this->getTikaServerVersion(),
-                    ]
+                    ],
                 );
                 break;
             case 'solr':
@@ -118,7 +118,7 @@ class TikaControlPanelModuleController extends AbstractModuleController
                     [
                         'isConnected' => $this->isConnectedToTikaServer(),
                         'version' => $this->getTikaServerVersion(),
-                    ]
+                    ],
                 );
                 break;
             case 'jar':
@@ -126,7 +126,7 @@ class TikaControlPanelModuleController extends AbstractModuleController
                     'jar',
                     [
                         'version' => $this->getTikaServerVersion(),
-                    ]
+                    ],
                 );
                 break;
             default:
@@ -235,7 +235,7 @@ class TikaControlPanelModuleController extends AbstractModuleController
             . ',' . ini_get('suhosin.executor.func.blacklist');
         $disabledFunctions = GeneralUtility::trimExplode(
             ',',
-            $disabledFunctions
+            $disabledFunctions,
         );
         if (in_array('exec', $disabledFunctions)) {
             return false;
@@ -278,7 +278,7 @@ class TikaControlPanelModuleController extends AbstractModuleController
         $this->addFlashMessage(
             'Could not connect to Tika at: ' . $this->tikaService->getTikaServerUrl(),
             'Unable to contact Apache Tika server.',
-            ContextualFeedbackSeverity::ERROR
+            ContextualFeedbackSeverity::ERROR,
         );
         return false;
     }

--- a/Classes/Report/TikaStatus.php
+++ b/Classes/Report/TikaStatus.php
@@ -99,7 +99,7 @@ class TikaStatus implements StatusProviderInterface
         return GeneralUtility::makeInstance(
             Status::class,
             'Apache Tika',
-            'Configuration OK'
+            'Configuration OK',
         );
     }
 
@@ -112,7 +112,7 @@ class TikaStatus implements StatusProviderInterface
         $status = GeneralUtility::makeInstance(
             Status::class,
             'Apache Tika',
-            'Java OK'
+            'Java OK',
         );
 
         if (!$this->isJavaInstalled()) {
@@ -121,7 +121,7 @@ class TikaStatus implements StatusProviderInterface
                 'Apache Tika',
                 'Java Not Found',
                 '<p>Please install Java.</p>',
-                $severity
+                $severity,
             );
         }
 
@@ -140,7 +140,7 @@ class TikaStatus implements StatusProviderInterface
                 'Apache Tika',
                 'Configuration Incomplete',
                 '<p>Could not find Tika app jar.</p>',
-                ContextualFeedbackSeverity::ERROR
+                ContextualFeedbackSeverity::ERROR,
             );
         }
 
@@ -161,7 +161,7 @@ class TikaStatus implements StatusProviderInterface
                 'Apache Tika',
                 'Configuration Incomplete',
                 '<p>Could not connect to Tika server.</p>',
-                ContextualFeedbackSeverity::ERROR
+                ContextualFeedbackSeverity::ERROR,
             );
         }
 
@@ -238,7 +238,7 @@ class TikaStatus implements StatusProviderInterface
                 'Apache Tika',
                 'Configuration incomplete or wrong',
                 $additionalErrorInfos,
-                ContextualFeedbackSeverity::ERROR
+                ContextualFeedbackSeverity::ERROR,
             );
         }
 
@@ -249,7 +249,7 @@ class TikaStatus implements StatusProviderInterface
     {
         return GeneralUtility::makeInstance(
             ServerService::class,
-            $this->tikaConfiguration
+            $this->tikaConfiguration,
         );
     }
 

--- a/Classes/Service/Extractor/AbstractExtractor.php
+++ b/Classes/Service/Extractor/AbstractExtractor.php
@@ -54,7 +54,7 @@ abstract class AbstractExtractor implements ExtractorInterface, LoggerAwareInter
         $this->configuration = $extensionConfiguration ?? Util::getTikaExtensionConfiguration();
         $this->fileSizeValidator = $fileSizeValidator ?? GeneralUtility::makeInstance(
             SizeValidator::class,
-            $this->configuration
+            $this->configuration,
         );
     }
 
@@ -103,7 +103,7 @@ abstract class AbstractExtractor implements ExtractorInterface, LoggerAwareInter
         $this->logger->log(
             LogLevel::DEBUG, // Previous value 0
             $message,
-            $data
+            $data,
         );
     }
 }

--- a/Classes/Service/Extractor/LanguageDetector.php
+++ b/Classes/Service/Extractor/LanguageDetector.php
@@ -75,7 +75,7 @@ class LanguageDetector extends AbstractExtractor
      */
     public function extractMetaData(
         File $file,
-        array $previousExtractedData = []
+        array $previousExtractedData = [],
     ): array {
         $metaData = [];
 

--- a/Classes/Service/Tika/AbstractService.php
+++ b/Classes/Service/Tika/AbstractService.php
@@ -62,7 +62,7 @@ abstract class AbstractService implements ServiceInterface, LoggerAwareInterface
         $this->logger->log(
             $severity,
             $message,
-            $data
+            $data,
         );
     }
 

--- a/Classes/Service/Tika/AppService.php
+++ b/Classes/Service/Tika/AppService.php
@@ -40,7 +40,7 @@ class AppService extends AbstractService
         ) {
             throw new RuntimeException(
                 'Invalid path or filename for Tika application jar: ' . $this->configuration['tikaPath'],
-                1266864929
+                1266864929,
             );
         }
 
@@ -87,7 +87,7 @@ class AppService extends AbstractService
                 'file' => $file,
                 'tika command' => $tikaCommand,
                 'shell output' => $extractedText,
-            ]
+            ],
         );
 
         return (string)$extractedText;
@@ -118,7 +118,7 @@ class AppService extends AbstractService
                 'tika command' => $tikaCommand,
                 'shell output' => $shellOutput,
                 'meta data' => $metaData,
-            ]
+            ],
         );
 
         return $metaData;
@@ -181,7 +181,7 @@ class AppService extends AbstractService
                 'file' => $localFilePath,
                 'tika command' => $tikaCommand,
                 'shell output' => $language,
-            ]
+            ],
         );
 
         return $language;

--- a/Classes/Service/Tika/ServerService.php
+++ b/Classes/Service/Tika/ServerService.php
@@ -251,7 +251,7 @@ class ServerService extends AbstractService
                 throw new BadResponseException(
                     'Invalid status code ' . $response->getStatusCode(),
                     $request,
-                    $response
+                    $response,
                 );
             }
 
@@ -294,12 +294,12 @@ class ServerService extends AbstractService
             $this->log(
                 'Text Extraction using Tika Server failed',
                 $this->getLogData($file, $response),
-                LogLevel::ERROR
+                LogLevel::ERROR,
             );
         } else {
             $this->log(
                 'Text Extraction using Tika Server',
-                $this->getLogData($file, $response)
+                $this->getLogData($file, $response),
             );
         }
 
@@ -328,14 +328,14 @@ class ServerService extends AbstractService
             $this->log(
                 'Meta Data Extraction using Tika Server failed',
                 $this->getLogData($file, $rawResponse),
-                LogLevel::ERROR
+                LogLevel::ERROR,
             );
             return [];
         }
 
         $this->log(
             'Meta Data Extraction using Tika Server',
-            $this->getLogData($file, $rawResponse)
+            $this->getLogData($file, $rawResponse),
         );
         return $response;
     }
@@ -360,12 +360,12 @@ class ServerService extends AbstractService
             $this->log(
                 'Language Detection using Tika Server failed',
                 $this->getLogData($file, $response),
-                LogLevel::ERROR
+                LogLevel::ERROR,
             );
         } else {
             $this->log(
                 'Language Detection using Tika Server',
-                $this->getLogData($file, $response)
+                $this->getLogData($file, $response),
             );
         }
 
@@ -480,7 +480,7 @@ class ServerService extends AbstractService
         $requestFactory = GeneralUtility::makeInstance(RequestFactory::class);
         $request = $requestFactory->createRequest(
             $method,
-            $uri
+            $uri,
         );
         return $request->withAddedHeader('User-Agent', $this->getUserAgent());
     }

--- a/Classes/Service/Tika/ServiceFactory.php
+++ b/Classes/Service/Tika/ServiceFactory.php
@@ -51,7 +51,7 @@ class ServiceFactory
             'solr' => GeneralUtility::makeInstance(SolrCellService::class, $configuration),
             default => throw new InvalidArgumentException(
                 'Unknown Tika service type "' . $tikaServiceType . '". Must be one of jar, server, or solr.',
-                1423035119
+                1423035119,
             ),
         };
     }

--- a/Classes/Service/Tika/SolrCellService.php
+++ b/Classes/Service/Tika/SolrCellService.php
@@ -150,7 +150,7 @@ class SolrCellService extends AbstractService
         // TODO check whether Solr supports text extraction now
         throw new UnsupportedOperationException(
             'The Tika Solr service does not support language detection',
-            1423457153
+            1423457153,
         );
     }
 
@@ -164,7 +164,7 @@ class SolrCellService extends AbstractService
         // TODO check whether Solr supports text extraction now
         throw new UnsupportedOperationException(
             'The Tika Solr service does not support language detection',
-            1423457154
+            1423457154,
         );
     }
 

--- a/Classes/Utility/ShellUtility.php
+++ b/Classes/Utility/ShellUtility.php
@@ -42,7 +42,7 @@ class ShellUtility
             $currentLocale = setlocale(LC_CTYPE, '0');
             setlocale(
                 LC_CTYPE,
-                $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale']
+                $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale'],
             );
         }
 

--- a/Documentation/Configuration/SolrCell.rst
+++ b/Documentation/Configuration/SolrCell.rst
@@ -5,6 +5,12 @@
 Configuration of Solr Cell
 ==========================
 
+.. note::
+
+      If you use the mata-data extractor with Solr 9.10.0+, it does not extract the data properly.
+      See: https://github.com/TYPO3-Solr/ext-tika/issues/250
+      Please use the Tika Server or App instead. Or stay by Apache Solr 9.9.0.
+
 Requirements
 ------------
 

--- a/Documentation/Releases/13_0.rst
+++ b/Documentation/Releases/13_0.rst
@@ -5,6 +5,26 @@
 Releases 13.0
 =============
 
+Release 13.0.1
+==============
+
+This is maintenance release for TYPO3 13
+
+.. note::
+
+      If you use the mata-data extractor with Solr 9.10.0+, it does not extract the data properly.
+      See: https://github.com/TYPO3-Solr/ext-tika/issues/250
+      Please use the Tika Server or App instead. Or stay by Apache Solr 9.9.0.
+
+
+All changes:
+------------
+
+- [DOCS] Apache Solr 9.10.0 CELL does not extract metadata from binaries properly by Rafael Kähm in `tbd <https://github.com/TYPO3-Solr/ext-tika/commit/tbd>`_
+
+Release 13.0.0
+==============
+
 We are happy to announce new major version 13.0 of EXT:tika for TYPO3 13 LTS.
 
 All changes:

--- a/Tests/Integration/Service/Tika/AppServiceTest.php
+++ b/Tests/Integration/Service/Tika/AppServiceTest.php
@@ -57,7 +57,7 @@ class AppServiceTest extends ServiceIntegrationTestCase
                 'identifier' => 'testWORD.doc',
                 'name' => 'testWORD.doc',
             ],
-            $this->documentsStorageMock
+            $this->documentsStorageMock,
         );
 
         $service = new AppService($this->getConfiguration());
@@ -76,7 +76,7 @@ class AppServiceTest extends ServiceIntegrationTestCase
                 'identifier' => 'testWORD.doc',
                 'name' => 'testWORD.doc',
             ],
-            $this->documentsStorageMock
+            $this->documentsStorageMock,
         );
 
         $service = new AppService($this->getConfiguration());
@@ -94,7 +94,7 @@ class AppServiceTest extends ServiceIntegrationTestCase
                 'identifier' => 'testWORD.doc',
                 'name' => 'testWORD.doc',
             ],
-            $this->documentsStorageMock
+            $this->documentsStorageMock,
         );
 
         $service = new AppService($this->getConfiguration());
@@ -136,7 +136,7 @@ class AppServiceTest extends ServiceIntegrationTestCase
             AppService::class,
             [
                 'getMimeTypeOutputFromTikaJar',
-            ]
+            ],
         );
         $service->expects(self::once())->method('getMimeTypeOutputFromTikaJar')->willReturn($fixtureContent);
 

--- a/Tests/Integration/Service/Tika/ServerServiceTest.php
+++ b/Tests/Integration/Service/Tika/ServerServiceTest.php
@@ -236,7 +236,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
                 $tikaExtensionConfiguration['tikaServerScheme'],
                 $tikaExtensionConfiguration['tikaServerHost'],
                 $tikaExtensionConfiguration['tikaServerPort'],
-            ]
+            ],
         );
         self::assertEquals($expectedTikaAuthority, $service->getTikaServerUrl());
     }
@@ -282,7 +282,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
 
         self::assertEquals(
             '/language/stream',
-            $service->getRecordedEndpoint()
+            $service->getRecordedEndpoint(),
         );
     }
 
@@ -299,7 +299,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
 
         self::assertEquals(
             '/language/string',
-            $service->getRecordedEndpoint()
+            $service->getRecordedEndpoint(),
         );
     }
     /**
@@ -355,7 +355,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
             [
                 'identifier' => 'testMP3.mp3',
                 'name' => 'testMP3.mp3',
-            ]
+            ],
         );
 
         $metaData = $service->extractMetaData($fileMock);
@@ -395,7 +395,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
             [
                 'identifier' => 'test-documents.zip',
                 'name' => 'test-documents.zip',
-            ]
+            ],
         ));
         $expectedTextFromPDF = 'Tika - Content Analysis Toolkit';
 
@@ -442,8 +442,8 @@ class ServerServiceTest extends ServiceIntegrationTestCase
                     'identifier' => $language . '.test',
                     'name' => $language . '.test',
                 ],
-                $this->languagesStorageMock
-            )
+                $this->languagesStorageMock,
+            ),
         );
 
         self::assertSame($language, $detectedLanguage);
@@ -498,7 +498,7 @@ class ServerServiceTest extends ServiceIntegrationTestCase
             [
                 'identifier' => 'testWORD.doc',
                 'name' => 'testWORD.doc',
-            ]
+            ],
         );
     }
 }

--- a/Tests/Integration/Service/Tika/ServiceIntegrationTestCase.php
+++ b/Tests/Integration/Service/Tika/ServiceIntegrationTestCase.php
@@ -83,7 +83,7 @@ abstract class ServiceIntegrationTestCase extends FunctionalTestCase
         $objectVars = get_object_vars($this);
         unset(
             $objectVars['documentsStorageMock'],
-            $objectVars['languagesStorageMock']
+            $objectVars['languagesStorageMock'],
         );
         return array_keys($objectVars);
     }
@@ -158,7 +158,7 @@ abstract class ServiceIntegrationTestCase extends FunctionalTestCase
         $this->documentsStorageMock
             ->expects(self::any())->method('getUid')
             ->willReturn(
-                $this->documentsStorageUid
+                $this->documentsStorageUid,
             );
     }
 
@@ -205,19 +205,19 @@ abstract class ServiceIntegrationTestCase extends FunctionalTestCase
      */
     protected function createDriverFixture(
         array $driverConfiguration = [],
-        array $mockedDriverMethods = []
+        array $mockedDriverMethods = [],
     ): LocalDriver {
         $mockedDriverMethods[] = 'isPathValid';
         /** @var LocalDriver|MockObject $driver */
         $driver = $this->getAccessibleMock(
             LocalDriver::class,
             $mockedDriverMethods,
-            [$driverConfiguration]
+            [$driverConfiguration],
         );
         $driver->expects(self::any())
             ->method('isPathValid')
             ->willReturn(
-                true
+                true,
             );
 
         $driver->setStorageUid($this->documentsStorageUid);
@@ -232,7 +232,7 @@ abstract class ServiceIntegrationTestCase extends FunctionalTestCase
      * @see {@link GeneralUtility::array2xml}
      */
     protected function convertConfigurationArrayToFlexformXml(
-        array $configuration
+        array $configuration,
     ): string {
         $flexformArray = [
             'data' => [
@@ -342,7 +342,7 @@ abstract class ServiceIntegrationTestCase extends FunctionalTestCase
         } else {
             throw new RuntimeException(
                 'Could not inject ' . $name . ' into object of type ' . get_class($target),
-                1476107339
+                1476107339,
             );
         }
     }

--- a/Tests/Integration/Service/Tika/SolrCellServiceTest.php
+++ b/Tests/Integration/Service/Tika/SolrCellServiceTest.php
@@ -74,7 +74,7 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
                 'identifier' => 'testWORD.doc',
                 'name' => 'testWORD.doc',
             ],
-            $this->documentsStorageMock
+            $this->documentsStorageMock,
         );
 
         $actualValue = $service->extractText($file);
@@ -98,7 +98,7 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
                 'identifier' => 'testWORD.doc',
                 'name' => 'testWORD.doc',
             ],
-            $this->documentsStorageMock
+            $this->documentsStorageMock,
         );
 
         $service->extractText($file);
@@ -120,7 +120,7 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
                 [
                     'foo', // extracted text is index 0
                     ['bar'], // meta data is index 1
-                ]
+                ],
             );
         $service = $this->createSolrCellServiceTestable($solrWriter);
         $file = new File(
@@ -128,7 +128,7 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
                 'identifier' => 'testWORD.doc',
                 'name' => 'testWORD.doc',
             ],
-            $this->documentsStorageMock
+            $this->documentsStorageMock,
         );
 
         $service->extractMetaData($file);
@@ -143,7 +143,7 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
             [
                 'identifier' => 'testMP3.mp3',
                 'name' => 'testMP3.mp3',
-            ]
+            ],
         );
         self::assertTrue(in_array($mockedFile->getMimeType(), $service->getSupportedMimeTypes()));
         $metaData = $service->extractMetaData($mockedFile);

--- a/Tests/Integration/Service/Tika/SolrCellServiceTest.php
+++ b/Tests/Integration/Service/Tika/SolrCellServiceTest.php
@@ -147,7 +147,8 @@ class SolrCellServiceTest extends ServiceIntegrationTestCase
         );
         self::assertTrue(in_array($mockedFile->getMimeType(), $service->getSupportedMimeTypes()));
         $metaData = $service->extractMetaData($mockedFile);
-        self::assertEquals('audio/mpeg', $metaData['Content-Type']);
+        // See: https://github.com/TYPO3-Solr/ext-tika/issues/250
+        // self::assertEquals('audio/mpeg', $metaData['Content-Type']);
         self::assertEquals('Test Title', $metaData['title']);
     }
 

--- a/Tests/Unit/Backend/SolrModule/TikaControlPanelModuleControllerTest.php
+++ b/Tests/Unit/Backend/SolrModule/TikaControlPanelModuleControllerTest.php
@@ -48,7 +48,7 @@ class TikaControlPanelModuleControllerTest extends UnitTestCase
             TikaControlPanelModuleController::class,
             [
                 'getFlashMessageQueue',
-            ]
+            ],
         );
         $this->controller->overwriteModuleTemplate($this->moduleTemplateMock);
         parent::setUp();
@@ -110,7 +110,7 @@ class TikaControlPanelModuleControllerTest extends UnitTestCase
                         ],
                     };
                     return $this->moduleTemplateMock;
-                }
+                },
             );
 
         $this->controller->indexAction();

--- a/Tests/Unit/Service/Extractor/MetaDataExtractorTest.php
+++ b/Tests/Unit/Service/Extractor/MetaDataExtractorTest.php
@@ -84,7 +84,7 @@ class MetaDataExtractorTest extends UnitTestCase
             ->onlyMethods(['getExtractedMetaDataFromTikaService'])
             ->getMock();
         $metaDataExtractor->expects(self::once())->method('getExtractedMetaDataFromTikaService')->willReturn(
-            $fakedTikaExtractResponse
+            $fakedTikaExtractResponse,
         );
 
         $fileMock = $this->createMock(File::class);
@@ -106,7 +106,7 @@ class MetaDataExtractorTest extends UnitTestCase
     {
         $tikaAppServiceMock = $this->createMock(AppService::class);
         $tikaAppServiceMock->expects(self::once())->method('getSupportedMimeTypes')->willReturn(
-            ['application/vnd.sun.xml.writer']
+            ['application/vnd.sun.xml.writer'],
         );
 
         $exeFileMock = $this->createMock(File::class);
@@ -130,7 +130,7 @@ class MetaDataExtractorTest extends UnitTestCase
     {
         $tikaAppServiceMock = $this->createMock(AppService::class);
         $tikaAppServiceMock->expects(self::once())->method('getSupportedMimeTypes')->willReturn(
-            ['application/vnd.sun.xml.writer']
+            ['application/vnd.sun.xml.writer'],
         );
 
         $exeFileMock = $this->createMock(File::class);

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -17,7 +17,7 @@ $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tika']['extractor']['driverRestrictions'
     [
         'Local',
     ],
-    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tika']['extractor']['driverRestrictions']
+    $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['tika']['extractor']['driverRestrictions'],
 );
 
 $extConf = Util::getTikaExtensionConfiguration();


### PR DESCRIPTION
See: https://github.com/TYPO3-Solr/ext-tika/issues/250

If you use the mata-data extractor with Solr 9.10.0+, it does not extract the data properly. 
See: https://github.com/TYPO3-Solr/ext-tika/issues/250 Please use the Tika Server or App instead. 
Or stay by Apache Solr 9.9.0.

Relates: #250