### PR TITLE
[BUGFIX] Add exception handling to metadata extraction

### DIFF
--- a/Classes/Service/Extractor/MetaDataExtractor.php
+++ b/Classes/Service/Extractor/MetaDataExtractor.php
@@ -78,7 +78,7 @@ class MetaDataExtractor extends AbstractExtractor
         try {
             $extractedMetaData = $this->getExtractedMetaDataFromTikaService($file);
         } catch (\Throwable $e) {
-            $this->logger->warning('Error while processing file uid=' . $file->getUid(). ' via Ext:tika: ' . $e->getMessage());
+            $this->logger->warning('Error while processing file uid=' . $file->getUid() . ' via Ext:tika: ' . $e->getMessage());
             $extractedMetaData = $previousExtractedData;
         }
         return $this->normalizeMetaData($extractedMetaData);

--- a/Classes/Service/Extractor/MetaDataExtractor.php
+++ b/Classes/Service/Extractor/MetaDataExtractor.php
@@ -72,15 +72,15 @@ class MetaDataExtractor extends AbstractExtractor
      *
      * @param File $file File to extract meta-data from
      * @param array $previousExtractedData Already extracted/existing data
-     *
-     * @throws ClientExceptionInterface
-     * @throws ExtensionConfigurationExtensionNotConfiguredException
-     * @throws ExtensionConfigurationPathDoesNotExistException
-     * @throws Throwable
      */
     public function extractMetaData(File $file, array $previousExtractedData = []): array
     {
-        $extractedMetaData = $this->getExtractedMetaDataFromTikaService($file);
+        try {
+            $extractedMetaData = $this->getExtractedMetaDataFromTikaService($file);
+        } catch (\Throwable $e) {
+            $this->logger->warning('Error while processing file uid=' . $file->getUid(). ' via Ext:tika: ' . $e->getMessage());
+            $extractedMetaData = $previousExtractedData;
+        }
         return $this->normalizeMetaData($extractedMetaData);
     }
 


### PR DESCRIPTION
Metadata extractor must not throw exceptions, as then the sys_file_metadata entry is not being created.

Wrap meta-data extraction in a try-catch block to handle exceptions and log errors.

Resolves: #260