### PR TITLE
[SECURITY] Escape backend output + warn about skipSecurityChecks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ typo3temp
 uploads
 var
 vendor
+
+# graphify knowledge graph output
+graphify-out/

--- a/Classes/Lowlevel/EventListener/BlindedSecrets.php
+++ b/Classes/Lowlevel/EventListener/BlindedSecrets.php
@@ -61,7 +61,10 @@ class BlindedSecrets
             $inputType = 'text';
         }
 
+        $fieldName = htmlspecialchars((string)$params['fieldName'], ENT_QUOTES);
+        $value = htmlspecialchars((string)$currentConfigValue, ENT_QUOTES);
+
         return /* @lang HTML */
-            "<input class='form-control' id='em-tika-{$params['fieldName']}' type='$inputType' name='{$params['fieldName']}' value='$currentConfigValue'>";
+            "<input class='form-control' id='em-tika-{$fieldName}' type='$inputType' name='{$fieldName}' value='$value'>";
     }
 }

--- a/Classes/Report/TikaStatus.php
+++ b/Classes/Report/TikaStatus.php
@@ -278,36 +278,50 @@ class TikaStatus implements StatusProviderInterface
             if (!is_null($extractedContent) && !empty($extractedMetadata)) {
                 $solrCellConfigurationOk = true;
             } elseif ($response instanceof ResponseAdapter) {
+                // Response data originates from an external Solr server and must be
+                // escaped before being rendered into the backend reports view.
+                $httpStatus = htmlspecialchars(
+                    $response->getHttpStatus() . ' ' . $response->getHttpStatusMessage(),
+                    ENT_QUOTES,
+                );
+                $responseBody = htmlspecialchars((string)$response->getRawResponse(), ENT_QUOTES);
                 $additionalErrorInfos = /* @lang HTML */
                 "
                 <table class='table table-condensed table-hover table-striped'>
                     <tbody>
                         <tr class='warning'>
-                            <th>Status:</th><td>{$response->getHttpStatus()} {$response->getHttpStatusMessage()}</td>
+                            <th>Status:</th><td>{$httpStatus}</td>
                         </tr>
                         <tr class='warning'>
                             <th>Response body:</th>
-                            <td>{$response->getRawResponse()}</td>
+                            <td>{$responseBody}</td>
                         </tr>
                     </tbody>
                 </table>
                 ";
             }
         } catch (Throwable $e) {
+            // Exception messages/traces can carry external server response data.
+            $exceptionSummary = htmlspecialchars(
+                'Exception: "' . $e->getMessage() . '" with code ' . $e->getCode()
+                . ' in ' . $e->getFile() . ' line ' . $e->getLine(),
+                ENT_QUOTES,
+            );
+            $exceptionTrace = htmlspecialchars($e->getTraceAsString(), ENT_QUOTES);
             $additionalErrorInfos = /* @lang HTML */
                 "
                 <div class='panel panel-default'>
                     <div class='panel-heading'>
                         <h3 class='panel-title'>
                             <a href='#panel-reports-status-tika-solr-cell' data-bs-toggle='collapse' class='collapsed' aria-expanded='false'>
-                                Exception: \"{$e->getMessage()}\" with code {$e->getCode()} in {$e->getFile()} line {$e->getLine()}
+                                {$exceptionSummary}
                             </a>
                         </h3>
                     </div>
 
                     <div id='panel-reports-status-tika-solr-cell' class='panel-collapse collapse'>
                         <div class='panel-body'>
-                            {$e->getTraceAsString()}
+                            {$exceptionTrace}
                         </div>
                     </div>
                 </div>

--- a/Classes/Utility/ShellUtility.php
+++ b/Classes/Utility/ShellUtility.php
@@ -27,7 +27,9 @@ class ShellUtility
     public static function getLanguagePrefix(): string
     {
         if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['UTF8filesystem']) && !Environment::isWindows()) {
-            return 'LC_CTYPE="' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale'] . '" ';
+            // systemLocale is prepended to a shell command; escape it to avoid
+            // breaking out of the LC_CTYPE assignment.
+            return 'LC_CTYPE=' . escapeshellarg((string)$GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale']) . ' ';
         }
         return '';
     }

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -48,6 +48,27 @@ Server - variant (recommended)
 The Server variant is the best one by set on supported features and is more performant as the App,
 but requires additional service and maintenance.
 
+..  _configuration-skip-security-checks:
+
+Skip Security Checks
+====================
+
+Disables EXT:tika's built-in security gate that blocks extraction when the connected Tika / Solr version is known to be vulnerable.
+Defaults to *off* and should stay off.
+
+..  warning::
+
+    Enabling :php:`skipSecurityChecks` re-exposes your installation to the known vulnerabilities the gate protects against, in particular:
+
+    * `CVE-2025-54988 <https://tika.apache.org/security.html>`_ (Apache Tika)
+    * `CVE-2025-66516 <https://solr.apache.org/security.html#cve-2025-66516-apache-solr-extraction-module-vulnerable-to-xxe-attacks-via-xfa-content-in-pdfs>`_
+      (Apache Solr Cell, XXE via XFA content in PDFs)
+
+    Only turn it on as a temporary measure when you cannot update Apache Tika (v. 3.2.3+) or Apache Solr (v. 9.10.1+) yet,
+    and you fully understand and accept the risk. Prefer updating the underlying service, or applying the upstream mitigation in ``solrconfig.xml``, over skipping the check.
+
+    Untrusted documents processed while this is enabled may be able to exploit the extraction backend.
+
 Enable Logging
 ==============
 

--- a/Documentation/Configuration/SolrCell.rst
+++ b/Documentation/Configuration/SolrCell.rst
@@ -13,6 +13,9 @@ Configuration of Solr Cell
       and set :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['tika']['skipSecurityChecks'] = true` on EXT:tika v 13.1.0+
       if you can not update the Apache Solr server.
 
+      Only do this as a temporary measure and read :ref:`Skip Security Checks <configuration-skip-security-checks>` first
+      — it re-exposes you to the vulnerability above.
+
 
 Requirements
 ------------

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -6,7 +6,7 @@
 # cat=general//10; type=options[Tika App=jar,Tika Server=server,Solr Server=solr]; label=Extractor: Choose a service to use for extraction.
 extractor = server
 
-# cat=general//20; type=boolean; label=Skip Security Checks
+# cat=general//20; type=boolean; label=Skip Security Checks: SECURITY RISK. Disables the vulnerable-version gate (CVE-2025-54988 / CVE-2025-66516). Only enable temporarily if you cannot update Tika 3.2.3+ / Solr 9.10.1+. Keep off in production.
 skipSecurityChecks = 0
 
 # cat=general//21; type=boolean; label=Enable Logging


### PR DESCRIPTION
## Summary

Hardens three backend-context output paths that rendered untrusted or external data without encoding, and documents `skipSecurityChecks` as a security footgun. All findings surfaced during a review of EXT:tika; none are exploitable by unprivileged users, but all cross output-encoding / trust boundaries.

## Changes

**Output encoding (`38624f1`)**
- `BlindedSecrets::hideInExtConf()` wrote the stored config value + field name straight into an `<input value='…'>` attribute → escape both with `htmlspecialchars(ENT_QUOTES)`.
- `TikaStatus` reports view rendered the raw Solr server HTTP response and exception message/trace unescaped (external-server → admin-browser trust boundary) → escape all reflected data.
- `ShellUtility::getLanguagePrefix()` concatenated `SYS/systemLocale` into a shell command inside double quotes without escaping → use `escapeshellarg()`.

**Docs (`9a1d778`)**
- Dedicated *Skip Security Checks* section with a warning admonition: enabling it re-exposes CVE-2025-54988 (Tika) and CVE-2025-66516 (Solr Cell XXE via XFA in PDFs); only a temporary measure until Tika 3.2.3+ / Solr 9.10.1+.
- Cross-referenced from the Solr Cell config note; risk also made visible inline in the Extension Configuration label.

## Verification

- `php -l` clean on all changed classes.
- Standalone check confirms `'`/`<>` are neutralised and safe values are unchanged; a malicious locale payload is inert inside single quotes.
- No test assertions reference the changed output (`LC_CTYPE` / `getRawResponse` / `hideInExtConf`).
- ⚠️ Full TYPO3 unit suite not run locally (`.Build/` not set up) — relying on CI. Changes are additive encoding only, no behavioural change for legitimate values.

## Notes

Independently mergeable and backportable to the v13 line. The TYPO3 v14 compatibility work stacks on top of this branch in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)