### PR TITLE
[TASK] TYPO3 v14 compatibility (StandaloneView migration + constraints)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,14 @@ jobs:
              ghcr.io/typo3-documentation/render-guides:latest --config=Documentation --no-progress --fail-on-log
   tests:
     runs-on: ubuntu-latest
+    # v14 rows are experimental until the TYPO3 v14 / EXT:solr 14 test setup
+    # is proven green; do not let them fail the whole pipeline meanwhile.
+    continue-on-error: ${{ contains(matrix.TYPO3, '14') }}
     strategy:
+      fail-fast: false
       matrix:
         PHP: [ '8.2', '8.3', '8.4' ]
-        TYPO3: [ '^13.4', '13.4.x-dev' ]
+        TYPO3: [ '^13.4', '13.4.x-dev', '^14.3', '14.0.x-dev' ]
     env:
       typo3DatabaseName: 'typo3_ci'
       typo3DatabaseHost: '127.0.0.1'

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ typo3temp
 uploads
 var
 vendor
+
+# graphify knowledge graph output
+graphify-out/

--- a/Classes/Controller/Backend/PreviewController.php
+++ b/Classes/Controller/Backend/PreviewController.php
@@ -31,13 +31,19 @@ use TYPO3\CMS\Core\Configuration\Exception\ExtensionConfigurationPathDoesNotExis
 use TYPO3\CMS\Core\Http\HtmlResponse;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Core\View\ViewFactoryData;
+use TYPO3\CMS\Core\View\ViewFactoryInterface;
+use TYPO3\CMS\Core\View\ViewInterface;
 
 /**
  * Class PreviewController
  */
 class PreviewController
 {
+    public function __construct(
+        private readonly ViewFactoryInterface $viewFactory,
+    ) {}
+
     /**
      * @throws ClientExceptionInterface
      * @throws Throwable
@@ -73,13 +79,13 @@ class PreviewController
             $language = 'not detectable';
         }
 
-        $view = $this->getInitializedPreviewView();
+        $view = $this->getInitializedPreviewView($request);
 
         $view->assign('metadata', $metadata);
         $view->assign('content', $content);
         $view->assign('language', $language);
 
-        $response->getBody()->write($view->render() ?? '');
+        $response->getBody()->write($view->render('Backend/Preview'));
 
         return $response;
     }
@@ -98,13 +104,13 @@ class PreviewController
         return GeneralUtility::makeInstance(ResourceFactory::class);
     }
 
-    protected function getInitializedPreviewView(): StandaloneView
+    protected function getInitializedPreviewView(ServerRequestInterface $request): ViewInterface
     {
-        /** @var StandaloneView $view */
-        $view = GeneralUtility::makeInstance(StandaloneView::class);
-        $templatePathAndFile = 'EXT:tika/Resources/Private/Templates/Backend/Preview.html';
-        $view->setTemplatePathAndFilename(GeneralUtility::getFileAbsFileName($templatePathAndFile));
-        return $view;
+        $viewFactoryData = new ViewFactoryData(
+            templateRootPaths: ['EXT:tika/Resources/Private/Templates/'],
+            request: $request,
+        );
+        return $this->viewFactory->create($viewFactoryData);
     }
 
     protected function getIsAdmin(): bool

--- a/Classes/Lowlevel/EventListener/BlindedSecrets.php
+++ b/Classes/Lowlevel/EventListener/BlindedSecrets.php
@@ -61,7 +61,10 @@ class BlindedSecrets
             $inputType = 'text';
         }
 
+        $fieldName = htmlspecialchars((string)$params['fieldName'], ENT_QUOTES);
+        $value = htmlspecialchars((string)$currentConfigValue, ENT_QUOTES);
+
         return /* @lang HTML */
-            "<input class='form-control' id='em-tika-{$params['fieldName']}' type='$inputType' name='{$params['fieldName']}' value='$currentConfigValue'>";
+            "<input class='form-control' id='em-tika-{$fieldName}' type='$inputType' name='{$fieldName}' value='$value'>";
     }
 }

--- a/Classes/Report/TikaStatus.php
+++ b/Classes/Report/TikaStatus.php
@@ -278,36 +278,50 @@ class TikaStatus implements StatusProviderInterface
             if (!is_null($extractedContent) && !empty($extractedMetadata)) {
                 $solrCellConfigurationOk = true;
             } elseif ($response instanceof ResponseAdapter) {
+                // Response data originates from an external Solr server and must be
+                // escaped before being rendered into the backend reports view.
+                $httpStatus = htmlspecialchars(
+                    $response->getHttpStatus() . ' ' . $response->getHttpStatusMessage(),
+                    ENT_QUOTES,
+                );
+                $responseBody = htmlspecialchars((string)$response->getRawResponse(), ENT_QUOTES);
                 $additionalErrorInfos = /* @lang HTML */
                 "
                 <table class='table table-condensed table-hover table-striped'>
                     <tbody>
                         <tr class='warning'>
-                            <th>Status:</th><td>{$response->getHttpStatus()} {$response->getHttpStatusMessage()}</td>
+                            <th>Status:</th><td>{$httpStatus}</td>
                         </tr>
                         <tr class='warning'>
                             <th>Response body:</th>
-                            <td>{$response->getRawResponse()}</td>
+                            <td>{$responseBody}</td>
                         </tr>
                     </tbody>
                 </table>
                 ";
             }
         } catch (Throwable $e) {
+            // Exception messages/traces can carry external server response data.
+            $exceptionSummary = htmlspecialchars(
+                'Exception: "' . $e->getMessage() . '" with code ' . $e->getCode()
+                . ' in ' . $e->getFile() . ' line ' . $e->getLine(),
+                ENT_QUOTES,
+            );
+            $exceptionTrace = htmlspecialchars($e->getTraceAsString(), ENT_QUOTES);
             $additionalErrorInfos = /* @lang HTML */
                 "
                 <div class='panel panel-default'>
                     <div class='panel-heading'>
                         <h3 class='panel-title'>
                             <a href='#panel-reports-status-tika-solr-cell' data-bs-toggle='collapse' class='collapsed' aria-expanded='false'>
-                                Exception: \"{$e->getMessage()}\" with code {$e->getCode()} in {$e->getFile()} line {$e->getLine()}
+                                {$exceptionSummary}
                             </a>
                         </h3>
                     </div>
 
                     <div id='panel-reports-status-tika-solr-cell' class='panel-collapse collapse'>
                         <div class='panel-body'>
-                            {$e->getTraceAsString()}
+                            {$exceptionTrace}
                         </div>
                     </div>
                 </div>

--- a/Classes/Service/Extractor/MetaDataExtractor.php
+++ b/Classes/Service/Extractor/MetaDataExtractor.php
@@ -163,14 +163,12 @@ class MetaDataExtractor extends AbstractExtractor
                     $metaDataCleaned['note'] = $value;
                     break;
                 case 'dcterms:created':
-                    $metaDataCleaned['content_creation_date'] = strtotime($value);
-                    break;
                 case 'Date/Time Original':
                     $metaDataCleaned['content_creation_date'] = $this->exifDateToTimestamp($value);
                     break;
                 case 'dcterms:modified':
                 case 'meta:save-date':
-                    $metaDataCleaned['content_modification_date'] = strtotime($value);
+                    $metaDataCleaned['content_modification_date'] = $this->exifDateToTimestamp($value);
                     break;
                 case 'xmpTPg:NPages':
                 case 'meta:page-count':
@@ -197,12 +195,10 @@ class MetaDataExtractor extends AbstractExtractor
      */
     protected function exifDateToTimestamp(string $date): int
     {
-        if (($timestamp = strtotime($date)) === -1) {
-            $date = 0;
-        } else {
-            $date = $timestamp;
-        }
+        // strtotime() returns false (not -1, as in PHP < 5.1) when the date
+        // string cannot be parsed; fall back to 0 in that case.
+        $timestamp = strtotime($date);
 
-        return $date;
+        return $timestamp === false ? 0 : $timestamp;
     }
 }

--- a/Classes/Service/Tika/ServerService.php
+++ b/Classes/Service/Tika/ServerService.php
@@ -22,6 +22,7 @@ use Psr\Container\ContainerExceptionInterface;
 use Psr\Container\NotFoundExceptionInterface;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\UriInterface;
 use Psr\Log\LogLevel;
@@ -161,13 +162,15 @@ class ServerService extends AbstractService
 
             $tikaOutput = $response->getBody()->getContents();
         } catch (Throwable $exception) {
+            // A genuinely unreachable Tika server surfaces as a PSR-18 network
+            // exception. Fall back to matching known connection-error messages
+            // for HTTP clients that do not throw the typed exception. Anything
+            // else is a real error and must propagate rather than be swallowed.
             $message = $exception->getMessage();
-            if (
-                !str_contains($message, 'Connection refused')   &&
-                !str_contains($message, 'HTTP request failed')
-            ) {
-                // If the server is simply not available it would say Connection refused
-                // since that is not the case something else went wrong
+            $serverUnavailable = $exception instanceof NetworkExceptionInterface
+                || str_contains($message, 'Connection refused')
+                || str_contains($message, 'HTTP request failed');
+            if (!$serverUnavailable) {
                 throw $exception;
             }
 

--- a/Classes/Utility/ShellUtility.php
+++ b/Classes/Utility/ShellUtility.php
@@ -27,7 +27,9 @@ class ShellUtility
     public static function getLanguagePrefix(): string
     {
         if (!empty($GLOBALS['TYPO3_CONF_VARS']['SYS']['UTF8filesystem']) && !Environment::isWindows()) {
-            return 'LC_CTYPE="' . $GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale'] . '" ';
+            // systemLocale is prepended to a shell command; escape it to avoid
+            // breaking out of the LC_CTYPE assignment.
+            return 'LC_CTYPE=' . escapeshellarg((string)$GLOBALS['TYPO3_CONF_VARS']['SYS']['systemLocale']) . ' ';
         }
         return '';
     }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -6,6 +6,13 @@ services:
   ApacheSolrForTypo3\Tika\:
     resource: '../Classes/*'
 
+  # Backend route target: needs to be public and autowired so the
+  # ViewFactoryInterface is injected into the constructor (the _defaults
+  # disable autowire for the rest of the extension).
+  ApacheSolrForTypo3\Tika\Controller\Backend\PreviewController:
+    public: true
+    autowire: true
+
   ApacheSolrForTypo3\Tika\Lowlevel\EventListener\BlindedSecrets:
     tags:
       - name: event.listener

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -34,13 +34,20 @@ App - variant (not recommended)
 So for example the App requires Java Runtime to exec and spawn a new java process for each processed file,
 but no network traffic for send files via wire.
 
-Solr Cell - variant
-~~~~~~~~~~~~~~~~~~~
+Solr Cell - variant (legacy)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Apache Solr Content Extraction Library (Solr Cell) variant does not support all the features supported by the App and by Server variants,
 but does not require to run and maintain any additional service/stack, if EXT:solr is already configured.
 Any connection/core used by EXT:solr can be reused there.
 Possible implications can be found on `Apache Solr docs page <https://solr.apache.org/guide/solr/latest/indexing-guide/indexing-with-tika.html#solr-cell-performance-implications>`_
+
+.. note::
+
+   Apache Solr is phasing Solr Cell out: the embedded Tika backend is deprecated
+   since Solr 9.10 and removed in Solr 10.0, where extraction is only possible by
+   delegating to an external Tika Server. Prefer the **Server** variant for new
+   setups. See :ref:`Configuration of Solr Cell <configuration-tika-solr-cell>`.
 
 Server - variant (recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -48,6 +48,32 @@ Server - variant (recommended)
 The Server variant is the best one by set on supported features and is more performant as the App,
 but requires additional service and maintenance.
 
+..  _configuration-skip-security-checks:
+
+Skip Security Checks
+====================
+
+Disables EXT:tika's built-in security gate that blocks extraction when the
+connected Tika / Solr version is known to be vulnerable. Defaults to *off* and
+should stay off.
+
+..  warning::
+
+    Enabling :php:`skipSecurityChecks` re-exposes your installation to the
+    known vulnerabilities the gate protects against, in particular:
+
+    * `CVE-2025-54988 <https://tika.apache.org/security.html>`_ (Apache Tika)
+    * `CVE-2025-66516 <https://solr.apache.org/security.html#cve-2025-66516-apache-solr-extraction-module-vulnerable-to-xxe-attacks-via-xfa-content-in-pdfs>`_
+      (Apache Solr Cell, XXE via XFA content in PDFs)
+
+    Only turn it on as a temporary measure when you cannot update Apache Tika
+    (v. 3.2.3+) or Apache Solr (v. 9.10.1+) yet, and you fully understand and
+    accept the risk. Prefer updating the underlying service, or applying the
+    upstream mitigation in ``solrconfig.xml``, over skipping the check.
+
+    Untrusted documents processed while this is enabled may be able to exploit
+    the extraction backend.
+
 Enable Logging
 ==============
 

--- a/Documentation/Configuration/SolrCell.rst
+++ b/Documentation/Configuration/SolrCell.rst
@@ -5,6 +5,23 @@
 Configuration of Solr Cell
 ==========================
 
+.. warning::
+
+      **Solr Cell is a legacy path.** Apache Solr deprecated the embedded
+      Tika backend (``LocalTikaExtractionBackend``) in Solr 9.10 and
+      **removed it in Solr 10.0** — from Solr 10 the extraction handler only
+      works by delegating to an *external* Apache Tika Server
+      (``tikaserver.url``). Apache itself states the embedded backend is
+      *"not recommended for use in a production system"* because a crashing
+      Tika parser can take down the whole Solr process.
+
+      For new setups, and for Solr 10+, prefer the
+      :ref:`Tika Server <configuration-tika-server>` extractor: same
+      features, better isolation, and independently patchable (see
+      :ref:`Skip Security Checks <configuration-skip-security-checks>` and
+      CVE-2025-66516). Solr Cell remains supported here for existing
+      installations.
+
 .. note::
 
       All Apache Solr versions prior v. 9.10.1 are vulnerable

--- a/Documentation/Configuration/SolrCell.rst
+++ b/Documentation/Configuration/SolrCell.rst
@@ -13,6 +13,10 @@ Configuration of Solr Cell
       and set :php:`$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['tika']['skipSecurityChecks'] = true` on EXT:tika v 13.1.0+
       if you can not update the Apache Solr server.
 
+      Only do this as a temporary measure and read
+      :ref:`Skip Security Checks <configuration-skip-security-checks>` first —
+      it re-exposes you to the vulnerability above.
+
 
 Requirements
 ------------

--- a/Tests/Unit/Backend/PreviewControllerTest.php
+++ b/Tests/Unit/Backend/PreviewControllerTest.php
@@ -29,7 +29,7 @@ use Throwable;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Resource\ResourceFactory;
-use TYPO3\CMS\Fluid\View\StandaloneView;
+use TYPO3\CMS\Core\View\ViewInterface;
 
 /**
  * Class PreviewControllerTest
@@ -68,7 +68,7 @@ class PreviewControllerTest extends UnitTestCase
 
         $controller->expects(self::once())->method('getIsAdmin')->willReturn(true);
         $controller->expects(self::once())->method('getConfiguredTikaService')->willReturn($serviceMock);
-        $controller->expects(self::once())->method('getInitializedPreviewView')->willReturn($this->createMock(StandaloneView::class));
+        $controller->expects(self::once())->method('getInitializedPreviewView')->willReturn($this->createMock(ViewInterface::class));
 
         $request = $this->createMock(ServerRequestInterface::class);
         $request->expects(self::once())->method('getQueryParams')->willReturn(['identifier' => '']);

--- a/composer.json
+++ b/composer.json
@@ -26,14 +26,14 @@
     "php": "^8.2",
     "ext-json": "*",
     "typo3/cms-backend": "*",
-    "typo3/cms-core": "^v13.4.2",
+    "typo3/cms-core": "^v13.4.2 || ^v14.3",
     "typo3/cms-extbase": "*",
     "typo3/cms-filemetadata": "*",
     "typo3/cms-fluid": "*",
     "typo3/cms-reports": "*"
   },
   "require-dev": {
-    "apache-solr-for-typo3/solr": "13.1.x-dev",
+    "apache-solr-for-typo3/solr": "13.1.x-dev || 14.0.x-dev",
     "dg/bypass-finals": "^1.6",
     "phpstan/phpstan": "^1.12",
     "phpstan/phpstan-phpunit": "^1.4",

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -6,7 +6,7 @@
 # cat=general//10; type=options[Tika App=jar,Tika Server=server,Solr Server=solr]; label=Extractor: Choose a service to use for extraction.
 extractor = server
 
-# cat=general//20; type=boolean; label=Skip Security Checks
+# cat=general//20; type=boolean; label=Skip Security Checks: SECURITY RISK. Disables the vulnerable-version gate (CVE-2025-54988 / CVE-2025-66516). Only enable temporarily if you cannot update Tika 3.2.3+ / Solr 9.10.1+. Keep off in production.
 skipSecurityChecks = 0
 
 # cat=general//21; type=boolean; label=Enable Logging

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -12,7 +12,7 @@ $EM_CONF[$_EXTKEY] = [
     'author_company' => 'dkd Internet Service GmbH',
     'constraints' => [
         'depends' => [
-            'typo3' => '13.4.2-13.4.99',
+            'typo3' => '13.4.2-14.4.99',
             'filemetadata' => '',
         ],
         'conflicts' => [],


### PR DESCRIPTION
## Summary

Prepares EXT:tika for TYPO3 v14. Stacks on top of #263 (base branch = `security/backend-output-encoding`) — review/merge #263 first, then this retargets cleanly to `main`.

The one true v14 blocker is the removal of `StandaloneView` in v14.0. Everything here keeps v13.4 working (single codebase for 13.4 **and** 14).

## Changes

**v14 blocker — `StandaloneView` → `ViewFactoryInterface` (`78663dc`)**
- `StandaloneView` was deprecated in v13.3 (#104773) and **removed in v14.0** (#105377) → fatal under v14.
- `PreviewController` now injects `ViewFactoryInterface` and builds the view via `ViewFactoryData(templateRootPaths, request)` + `create()` (API available since v13.3, so compatible with 13.4 and 14).
- `PreviewController` registered as a public, autowired service (the extension `_defaults` disable autowire).
- `PreviewControllerTest` mocks `ViewInterface` instead of the removed `StandaloneView`.

**Robustness fixes (`25a3af4`)**
- `MetaDataExtractor::exifDateToTimestamp()` checked `strtotime()` against `-1` (dead code since PHP 5.1) and stored raw `false` into date metadata → all date cases now go through the corrected helper returning `0` on failure.
- `ServerService::queryTika()` only swallowed "server unavailable" via fragile message substring matching → also treat PSR-18 `NetworkExceptionInterface`, keeping the string checks as fallback.

**Docs (`6250a88`)**
- Mark Solr Cell as a legacy path (Apache removed the embedded Tika backend in Solr 10.0; recommends external Tika Server), point users to the Server extractor.

**Constraints + CI (`7a4c6b8`, experimental)**
- `typo3/cms-core` → `^v13.4.2 || ^v14.3`; dev dep `apache-solr-for-typo3/solr` → `13.1.x-dev || 14.0.x-dev` (EXT:solr has a v14 line: 14.0.0-RC1 / 14.0.x-dev requiring cms-core ^14.3).
- `ext_emconf.php` → `13.4.2-14.4.99`.
- CI matrix adds `^14.3` and `14.0.x-dev` with `fail-fast: false` + `continue-on-error` for v14 rows.

## Verification status

- ✅ `php -l` clean on all changed PHP; `composer.json` valid JSON; `ci.yml` valid YAML.
- ✅ StandaloneView migration matches the official ViewFactory API (changelog #104773); template is self-contained; no use of other v14-removed APIs (`ReportInterface`, `sys_file_metadata.visible/fe_groups` — checked, no hits). `TikaStatus` uses `StatusProviderInterface`, which is **not** removed in v14.
- ⚠️ **Not yet verified in CI:** the v14 Composer resolution + test setup (cannot run Composer locally). Watch the experimental v14 matrix rows on first push and iterate on the EXT:solr dev-branch resolution if red.
- ⚠️ Full unit/functional suite not run locally.

## Follow-ups (not in this PR)
- Confirm `type=user[...]` ext-conf field renderer still works in the v14 backend.
- Once v14 CI is green, drop `continue-on-error` and align `extra.TYPO3-Solr` require metadata for the v14 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)