### PR TITLE
Release 14.0.0

### DIFF
--- a/Documentation/Releases/14_0.rst
+++ b/Documentation/Releases/14_0.rst
@@ -41,12 +41,24 @@ See :ref:`Configuration of Tika Server <configuration-tika-server>` for details.
 All changes since 13.1.0:
 -------------------------
 
-- TBD...
+- [TASK] Prepare main branch for TYPO3 14 version by Rafael Kähm `3ffb5da <https://github.com/TYPO3-Solr/ext-tika/commit/3ffb5da>`_
+- [TASK] TYPO3 v14 compatibility by Rafael Kähm `7297be3 <https://github.com/TYPO3-Solr/ext-tika/commit/7297be3>`_
+- [TASK] TYPO3 v14 compatibility: PHPStan issues by Rafael Kähm `688d26d <https://github.com/TYPO3-Solr/ext-tika/commit/688d26d>`_
+- [TASK] update GitHub Actions versions by Rafael Kähm `ef1a0bd <https://github.com/TYPO3-Solr/ext-tika/commit/ef1a0bd>`_
+- [TASK] Replace removed StandaloneView with ViewFactoryInterface by Olivier Dobberkau `bf70b7b <https://github.com/TYPO3-Solr/ext-tika/commit/bf70b7b>`_
+- !!![TASK] remove Solr Cell support by Rafael Kähm `f628549 <https://github.com/TYPO3-Solr/ext-tika/commit/f628549>`_
+- [FEATURE] Add Basic-Auth and timeout configuration for Tika Server by Rafael Kähm `091025a <https://github.com/TYPO3-Solr/ext-tika/commit/091025a>`_
+- [SECURITY] Escape backend output to prevent XSS and shell injection by Olivier Dobberkau `e1bca94 <https://github.com/TYPO3-Solr/ext-tika/commit/e1bca94>`_
+- [DOCS] Warn about skipSecurityChecks re-exposing known CVEs by Olivier Dobberkau `97d391e <https://github.com/TYPO3-Solr/ext-tika/commit/97d391e>`_
+- [BUGFIX] Harden date parsing and Tika server error handling by Olivier Dobberkau `635db49 <https://github.com/TYPO3-Solr/ext-tika/commit/635db49>`_
+- [BUGFIX] Add exception handling to metadata extraction by Mario Lubenka `3c763b4 <https://github.com/TYPO3-Solr/ext-tika/commit/3c763b4>`_
+- [BUGFIX] Deduplicate array values in metadata normalization by Rafael Kähm `2f9cce4 <https://github.com/TYPO3-Solr/ext-tika/commit/2f9cce4>`_
 
 
 Contributors
 ------------
 
+*   Mario Lubenka
 *   Markus Friedrich
 *   Olivier Dobberkau
 *   Rafael Kähm


### PR DESCRIPTION
This release adds full TYPO3 14 LTS support and removes the Apache Solr Cell extractor, since Apache Solr no longer ships a usable embedded Tika backend. The Tika Server extractor gains configurable HTTP Basic-Auth and connect/request timeouts, plus a raw Guzzle-options escape hatch for anything else. Metadata extraction is hardened to degrade gracefully instead of failing the whole file-metadata record on a Tika error, and duplicated array values from synced IPTC/XMP fields no longer produce repeated comma-separated metadata.

Please read the release notes and EXT:tika documentation before updating:

https://github.com/TYPO3-Solr/ext-tika/releases/tag/14.0.0

---

How to Get Involved

There are many ways to get involved with Apache Solr for TYPO3:

* Submit bug reports and feature requests on GitHub
* Ask or help or answer questions in our Slack channel
* Provide patches through pull requests or review and comment on existing pull requests
* Go to www.typo3-solr.com or call dkd to sponsor the ongoing development of Apache Solr for TYPO3

Support us by becoming an EB partner:
https://shop.dkd.de/Produkte/Apache-Solr-fuer-TYPO3/

or call:
+49 (0)69 - 2475218 0